### PR TITLE
668 info buttons adjusted

### DIFF
--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
@@ -29,6 +29,8 @@ function ModelConfigurationSlider({
 		setValue(config.value);
 	}, [config]);
 
+	const supportText = `more info about ${config.name}`;
+
 	return (
 		<div>
 			<div className="model-config-info">
@@ -37,13 +39,13 @@ function ModelConfigurationSlider({
 				</div>
 				<button
 					className="model-config-info-icon prompt-injection-min-button"
-					title="click for more info"
-					aria-label="click for more info"
+					title={supportText}
+					aria-label={supportText}
 					onClick={() => {
 						toggleInfo();
 					}}
 				>
-					<AiOutlineInfoCircle />
+					<AiOutlineInfoCircle aria-hidden />
 				</button>
 			</div>
 			{showInfo && <div className="model-config-info-text">{config.info}</div>}


### PR DESCRIPTION
# Feature Request

## Description
Improves accessibility and titles of the Model Temperature, Top P, Presence Penalty and Frequency Penalty sliders in the Model Configuration settings. 

## Screenshots

![Image](https://github.com/ScottLogic/prompt-injection/assets/125262707/feebee4f-d005-41fa-a938-f3d8852957db)

Before
![Image](https://github.com/ScottLogic/prompt-injection/assets/125262707/36956426-6cba-493c-8965-730965163bf7)

After
![Image](https://github.com/ScottLogic/prompt-injection/assets/125262707/1a6f781a-cdaf-4e07-8603-2e6cab1e2e72)


## Additional context
- adjusted the aria-label and title of the info buttons to include the name of the control
- added aria-hidden to the info icons (the buttons already have labels, so the icons are purely decorative)

## Acceptance criteria

**GIVEN** a screen reader user interacts with the Model Configuration
**WHEN** they focus on the Model Temperature, Top P, Presence Penalty, and Frequency Penalty info icons 
**THEN** they know which setting the button will give them more info for

**GIVEN** a user is in the Model Configuration menu
**WHEN** when they hover over Model Temperature, Top P, Presence Penalty, and Frequency Penalty info icons 
**THEN** the title (hover text) of the info icon tells them which setting the button will give them more info for

**GIVEN** a screen reader user interacts with the Model Configuration
**WHEN** they focus on the Model Temperature, Top P, Presence Penalty, and Frequency Penalty info icons 
**THEN** they only see the button in the accessibility tree, not the graphics-document
