### PR TITLE
676 switched input and export/reset buttons

### DIFF
--- a/frontend/src/components/ChatBox/ChatBox.tsx
+++ b/frontend/src/components/ChatBox/ChatBox.tsx
@@ -202,17 +202,6 @@ function ChatBox({
 		<div className="chat-box">
 			<ChatBoxFeed messages={messages} />
 			<div className="footer">
-				<div className="control-buttons">
-					<ExportPDFLink
-						messages={messages}
-						emails={emails}
-						currentLevel={currentLevel}
-					/>
-					<button className="chat-button" onClick={resetLevel}>
-						Reset Level
-					</button>
-				</div>
-
 				<div className="messages">
 					<ChatBoxInput
 						content={chatInput}
@@ -228,6 +217,16 @@ function ChatBox({
 							send
 						</LoadingButton>
 					</span>
+				</div>
+				<div className="control-buttons">
+					<ExportPDFLink
+						messages={messages}
+						emails={emails}
+						currentLevel={currentLevel}
+					/>
+					<button className="chat-button" onClick={resetLevel}>
+						Reset Level
+					</button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Description
Reversed the order of 
- input, send button
and 
- export chat,  reset level buttons

## Screenshot Outcome:
![Image](https://github.com/ScottLogic/prompt-injection/assets/125262707/9bd148f2-c0c8-41e0-a920-09a339e95bf7)

## Additional context
This is helpful for keyboard-only users (going between the chat and the configurations for example), assistive tech, and means the export chat & reset buttons stay in place even as the chat input expands with larger input. 

## Acceptance criteria
**GIVEN** the user chats with the chatbot
**WHEN** they tab through the interactive elements
**THEN** the input and send button come before the export chat and reset level buttons.
