### PR TITLE
620-email-ui-fix

### DIFF
--- a/frontend/src/components/EmailBox/EmailBox.css
+++ b/frontend/src/components/EmailBox/EmailBox.css
@@ -6,4 +6,5 @@
 	overflow-y: auto;
 	padding: 1rem;
 	scrollbar-width: thin;
+	gap: 1rem;
 }

--- a/frontend/src/components/EmailBox/SentEmail.css
+++ b/frontend/src/components/EmailBox/SentEmail.css
@@ -2,14 +2,8 @@
 	--horizontal-padding: 1rem;
 	--vertical-padding: 0.5rem;
 	color: var(--email-text-colour);
-	padding-bottom: 1rem;
-	border-radius: 0.625rem;
-	overflow: hidden;
+	--border-radius: 0.625rem;
 	white-space: pre-line;
-}
-
-.sent-email:first-child {
-	padding-bottom: 0;
 }
 
 .sent-email .sent-email-title {
@@ -19,6 +13,8 @@
 	display: flex;
 	gap: 1rem;
 	align-items: center;
+	border-top-left-radius: var(--border-radius);
+	border-top-right-radius: var(--border-radius);
 }
 
 .sent-email .sent-email-main {
@@ -27,6 +23,9 @@
 
 	font-family: courier;
 	font-weight: 400;
+
+	border-bottom-left-radius: var(--border-radius);
+	border-bottom-right-radius: var(--border-radius);
 }
 
 .sent-email .sent-email-main p {


### PR DESCRIPTION
## Description

Makes emails behave properly when they fill up the sent emails container. [Bug found in testing](https://github.com/ScottLogic/prompt-injection/issues/620#issuecomment-1860018216).

## Screenshots

![image](https://github.com/ScottLogic/prompt-injection/assets/118171430/3b577523-7844-4551-b03a-f83feb1fea78)

## Notes

- Fixed it by removing `overflow: hidden`. However, I couldn't keep `the border-radius` property without the overflow property. It would cause the rounded corners on the outer div, bu the inner divs wouldn't get clipped, and they would remain with their radius-0 corners, so no visual change. So I've had to apply the `border-radius` directly to the child elements.

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
