### PR TITLE
677 group configurations in fieldset where possible

### DIFF
--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.css
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.css
@@ -2,23 +2,22 @@ fieldset {
 	border: none;
 	margin: 0;
 	padding: 0;
-}
-
-.model-config-info {
 	display: flex;
-	align-items: center;
-	padding: 0.5rem 0;
+	flex-direction: column;
 }
 
-.model-config-info legend {
+legend {
 	margin-right: auto;
 }
 
-.model-config-info-icon {
+.info-icon {
 	font-size: 1.3rem;
+	margin-left: auto;
+	margin-top: -1.3rem;
+	margin-bottom: 1rem;
 }
 
-.model-config-info-text {
+.info-text {
 	font-size: 0.875rem;
 }
 

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.css
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.css
@@ -1,4 +1,4 @@
-fieldset {
+.model-config-slider-fieldset {
 	border: none;
 	margin: 0;
 	padding: 0;
@@ -6,7 +6,7 @@ fieldset {
 	flex-direction: column;
 }
 
-legend {
+.model-config-slider-fieldset legend {
 	margin-right: auto;
 }
 
@@ -24,7 +24,7 @@ legend {
 .model-config-slider {
 	width: 90%;
 	margin: 0 auto;
-	padding: 0 0 0 0;
+	padding: 0;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.css
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.css
@@ -11,10 +11,7 @@
 .model-config-info {
 	display: flex;
 	align-items: center;
-}
-
-.model-config-title {
-	margin-right: auto;
+	padding-bottom: 0.5rem;
 }
 
 .model-config-info-icon {
@@ -23,4 +20,13 @@
 
 .model-config-info-text {
 	font-size: 0.875rem;
+}
+
+fieldset {
+	border: 0;
+	padding: 0;
+}
+
+legend {
+	margin-right: auto;
 }

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.css
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.css
@@ -10,18 +10,18 @@
 	margin-right: auto;
 }
 
-.info-icon {
+.model-config-slider-fieldset .info-icon {
 	font-size: 1.3rem;
 	margin-left: auto;
 	margin-top: -1.3rem;
 	margin-bottom: 1rem;
 }
 
-.info-text {
+.model-config-slider-fieldset .info-text {
 	font-size: 0.875rem;
 }
 
-.model-config-slider {
+.model-config-slider-fieldset .config-slider {
 	width: 90%;
 	margin: 0 auto;
 	padding: 0;

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.css
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.css
@@ -1,17 +1,17 @@
-.model-config-slider {
-	width: 90%;
-	margin: 0 auto;
-	padding: 0 0 0 0;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
+fieldset {
+	border: none;
+	margin: 0;
+	padding: 0;
 }
 
 .model-config-info {
 	display: flex;
 	align-items: center;
-	padding-bottom: 0.5rem;
+	padding: 0.5rem 0;
+}
+
+.model-config-info legend {
+	margin-right: auto;
 }
 
 .model-config-info-icon {
@@ -22,11 +22,12 @@
 	font-size: 0.875rem;
 }
 
-fieldset {
-	border: 0;
-	padding: 0;
-}
-
-legend {
-	margin-right: auto;
+.model-config-slider {
+	width: 90%;
+	margin: 0 auto;
+	padding: 0 0 0 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
 }

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
@@ -43,7 +43,7 @@ function ModelConfigurationSlider({
 				<AiOutlineInfoCircle aria-hidden />
 			</button>
 			{showInfo && <div className="info-text">{config.info}</div>}
-			<div className="model-config-slider">
+			<div className="config-slider">
 				<Slider
 					aria-label={config.id}
 					getAriaValueText={(value) => `${value}`}

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
@@ -29,14 +29,12 @@ function ModelConfigurationSlider({
 		setValue(config.value);
 	}, [config]);
 
-	const supportText = `more info about ${config.name}`;
-
 	return (
 		<fieldset className="model-config-slider-fieldset">
 			<legend>{config.name}</legend>
 			<button
 				className="info-icon prompt-injection-min-button"
-				title={supportText}
+				title="more info"
 				aria-label="more info"
 				onClick={() => {
 					toggleInfo();

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
@@ -32,7 +32,7 @@ function ModelConfigurationSlider({
 	const supportText = `more info about ${config.name}`;
 
 	return (
-		<fieldset>
+		<fieldset className="model-config-slider-fieldset">
 			<legend>{config.name}</legend>
 			<button
 				className="info-icon prompt-injection-min-button"

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
@@ -32,11 +32,9 @@ function ModelConfigurationSlider({
 	const supportText = `more info about ${config.name}`;
 
 	return (
-		<div>
+		<fieldset>
 			<div className="model-config-info">
-				<div className="model-config-title">
-					<p>{config.name}</p>
-				</div>
+				<legend>{config.name}</legend>
 				<button
 					className="model-config-info-icon prompt-injection-min-button"
 					title={supportText}
@@ -64,7 +62,7 @@ function ModelConfigurationSlider({
 					}}
 				/>
 			</div>
-		</div>
+		</fieldset>
 	);
 }
 

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
@@ -49,7 +49,6 @@ function ModelConfigurationSlider({
 				<Slider
 					aria-label={config.id}
 					getAriaValueText={(value) => `${value}`}
-					aria-labelledby="slider"
 					min={config.min}
 					max={config.max}
 					step={0.1}

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
@@ -37,7 +37,7 @@ function ModelConfigurationSlider({
 			<button
 				className="info-icon prompt-injection-min-button"
 				title={supportText}
-				aria-label={supportText}
+				aria-label="more info"
 				onClick={() => {
 					toggleInfo();
 				}}

--- a/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
+++ b/frontend/src/components/ModelBox/ModelConfigurationSlider.tsx
@@ -33,24 +33,23 @@ function ModelConfigurationSlider({
 
 	return (
 		<fieldset>
-			<div className="model-config-info">
-				<legend>{config.name}</legend>
-				<button
-					className="model-config-info-icon prompt-injection-min-button"
-					title={supportText}
-					aria-label={supportText}
-					onClick={() => {
-						toggleInfo();
-					}}
-				>
-					<AiOutlineInfoCircle aria-hidden />
-				</button>
-			</div>
-			{showInfo && <div className="model-config-info-text">{config.info}</div>}
+			<legend>{config.name}</legend>
+			<button
+				className="info-icon prompt-injection-min-button"
+				title={supportText}
+				aria-label={supportText}
+				onClick={() => {
+					toggleInfo();
+				}}
+			>
+				<AiOutlineInfoCircle aria-hidden />
+			</button>
+			{showInfo && <div className="info-text">{config.info}</div>}
 			<div className="model-config-slider">
 				<Slider
 					aria-label={config.id}
 					getAriaValueText={(value) => `${value}`}
+					aria-labelledby="slider"
 					min={config.min}
 					max={config.max}
 					step={0.1}


### PR DESCRIPTION
## Description

## Screenshots

UI appearance is the same. 
fieldset grouping

![image](https://github.com/ScottLogic/prompt-injection/assets/118981273/42d624fb-7ad9-4e0c-ac93-39113c995c9b)



## Notes

- Wrapped ModelConfigurationSlider in <fieldset>
- changes` <p>config.name</p> to <legend>`
- some styling

## Concerns

* I found that i couldn't position the legend to appear on the same line as the button (it would always take up a line to itself - think this is by design as found others complaining about it online?) - workaround was to use a negative margin-top on the button to get on the same line - not ideal but looks like it looks fine on different size screens.. 

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
