### PR TITLE
fix failing test

### DIFF
--- a/backend/test/integration/chatController.test.ts
+++ b/backend/test/integration/chatController.test.ts
@@ -251,7 +251,7 @@ describe('handleChatToGPT integration tests', () => {
 
 		expect(res.status).toHaveBeenCalledWith(500);
 		expect(res.send).toHaveBeenCalledWith(
-			errorResponseMock('OpenAI error', {
+			errorResponseMock('Failed to get ChatGPT reply.', {
 				transformedMessage: 'hello',
 				openAIErrorMessage: 'OpenAI error',
 			})


### PR DESCRIPTION
## Description
closes #493
I broke the tests at the last minute before merging #684 , so here's the fix.

What broke the test was I changed the main message in the response object to say "failed to get ChatGPT reply." instead of whatever error was thrown by OpenAI


## Checklist

Have you done the following?

- [ ] Linked the relevant Issue
- [ ] Added tests
- [ ] Ensured the workflow steps are passing
