### PR TITLE
585 replace activate/deactivate functions with toggle on frontend

### DIFF
--- a/frontend/src/components/ControlPanel/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel/ControlPanel.tsx
@@ -10,18 +10,16 @@ function ControlPanel({
 	currentLevel,
 	defences,
 	chatModelOptions,
+	toggleDefence,
 	resetDefenceConfiguration,
-	setDefenceActive,
-	setDefenceInactive,
 	setDefenceConfiguration,
 	openDocumentViewer,
 }: {
 	currentLevel: LEVEL_NAMES;
 	defences: Defence[];
 	chatModelOptions: string[];
+	toggleDefence: (defence: Defence) => void;
 	resetDefenceConfiguration: (defenceId: DEFENCE_ID, configId: string) => void;
-	setDefenceActive: (defence: Defence) => void;
-	setDefenceInactive: (defence: Defence) => void;
 	setDefenceConfiguration: (
 		defenceId: DEFENCE_ID,
 		config: DefenceConfigItem[]
@@ -66,8 +64,7 @@ function ControlPanel({
 							defences={getDefencesConfigure()}
 							showConfigurations={showConfigurations}
 							resetDefenceConfiguration={resetDefenceConfiguration}
-							setDefenceActive={setDefenceActive}
-							setDefenceInactive={setDefenceInactive}
+							toggleDefence={toggleDefence}
 							setDefenceConfiguration={setDefenceConfiguration}
 						/>
 					</details>
@@ -80,9 +77,8 @@ function ControlPanel({
 							currentLevel={currentLevel}
 							defences={getDefencesModel()}
 							showConfigurations={showConfigurations}
+							toggleDefence={toggleDefence}
 							resetDefenceConfiguration={resetDefenceConfiguration}
-							setDefenceActive={setDefenceActive}
-							setDefenceInactive={setDefenceInactive}
 							setDefenceConfiguration={setDefenceConfiguration}
 						/>
 

--- a/frontend/src/components/DefenceBox/DefenceBox.tsx
+++ b/frontend/src/components/DefenceBox/DefenceBox.tsx
@@ -7,17 +7,15 @@ import './DefenceBox.css';
 function DefenceBox({
 	defences,
 	showConfigurations,
+	toggleDefence,
 	resetDefenceConfiguration,
-	setDefenceActive,
-	setDefenceInactive,
 	setDefenceConfiguration,
 }: {
 	currentLevel: number;
 	defences: Defence[];
 	showConfigurations: boolean;
+	toggleDefence: (defence: Defence) => void;
 	resetDefenceConfiguration: (defenceId: DEFENCE_ID, configId: string) => void;
-	setDefenceActive: (defence: Defence) => void;
-	setDefenceInactive: (defence: Defence) => void;
 	setDefenceConfiguration: (
 		defenceId: DEFENCE_ID,
 		config: DefenceConfigItem[]
@@ -31,9 +29,8 @@ function DefenceBox({
 						key={index}
 						defenceDetail={defence}
 						showConfigurations={showConfigurations}
+						toggleDefence={toggleDefence}
 						resetDefenceConfiguration={resetDefenceConfiguration}
-						setDefenceActive={setDefenceActive}
-						setDefenceInactive={setDefenceInactive}
 						setDefenceConfiguration={setDefenceConfiguration}
 					/>
 				);

--- a/frontend/src/components/DefenceBox/DefenceMechanism.tsx
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.tsx
@@ -11,16 +11,14 @@ import './DefenceMechanism.css';
 function DefenceMechanism({
 	defenceDetail,
 	showConfigurations,
+	toggleDefence,
 	resetDefenceConfiguration,
-	setDefenceActive,
-	setDefenceInactive,
 	setDefenceConfiguration,
 }: {
 	defenceDetail: Defence;
 	showConfigurations: boolean;
+	toggleDefence: (defence: Defence) => void;
 	resetDefenceConfiguration: (defenceId: DEFENCE_ID, configId: string) => void;
-	setDefenceActive: (defence: Defence) => void;
-	setDefenceInactive: (defence: Defence) => void;
 	setDefenceConfiguration: (
 		defenceId: DEFENCE_ID,
 		config: DefenceConfigItem[]
@@ -63,13 +61,6 @@ function DefenceMechanism({
 			showDefenceConfiguredText(false);
 		}
 	}
-
-	function toggleDefence() {
-		defenceDetail.isActive
-			? setDefenceInactive(defenceDetail)
-			: setDefenceActive(defenceDetail);
-	}
-
 	return (
 		<details
 			className="defence-mechanism"
@@ -85,7 +76,9 @@ function DefenceMechanism({
 					<input
 						type="checkbox"
 						placeholder="defence-toggle"
-						onChange={toggleDefence}
+						onChange={() => {
+							toggleDefence(defenceDetail);
+						}}
 						// set checked if defence is active
 						checked={defenceDetail.isActive}
 						aria-label={defenceDetail.name}

--- a/frontend/src/components/MainComponent/MainBody.tsx
+++ b/frontend/src/components/MainComponent/MainBody.tsx
@@ -20,8 +20,7 @@ function MainBody({
 	addSentEmails,
 	resetDefenceConfiguration,
 	resetLevel,
-	setDefenceActive,
-	setDefenceInactive,
+	toggleDefence,
 	setDefenceConfiguration,
 	incrementNumCompletedLevels,
 	openLevelsCompleteOverlay,
@@ -36,8 +35,7 @@ function MainBody({
 	addSentEmails: (emails: EmailInfo[]) => void;
 	resetDefenceConfiguration: (defenceId: DEFENCE_ID, configId: string) => void;
 	resetLevel: () => void;
-	setDefenceActive: (defence: Defence) => void;
-	setDefenceInactive: (defence: Defence) => void;
+	toggleDefence: (defence: Defence) => void;
 	setDefenceConfiguration: (
 		defenceId: DEFENCE_ID,
 		config: DefenceConfigItem[]
@@ -68,9 +66,8 @@ function MainBody({
 					currentLevel={currentLevel}
 					defences={defences}
 					chatModelOptions={chatModels}
+					toggleDefence={toggleDefence}
 					resetDefenceConfiguration={resetDefenceConfiguration}
-					setDefenceActive={setDefenceActive}
-					setDefenceInactive={setDefenceInactive}
 					setDefenceConfiguration={setDefenceConfiguration}
 					openDocumentViewer={openDocumentViewer}
 				/>

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -12,9 +12,8 @@ import {
 	getChatHistory,
 } from '@src/service/chatService';
 import {
-	activateDefence,
+	toggleDefence,
 	configureDefence,
-	deactivateDefence,
 	getDefences,
 	resetActiveDefences,
 	resetDefenceConfig,
@@ -187,33 +186,19 @@ function MainComponent({
 		setDefencesToShow(newDefences);
 	}
 
-	async function setDefenceActive(defence: Defence) {
-		await activateDefence(defence.id, currentLevel);
-		// update state
-		const newDefenceDetails = defencesToShow.map((defenceDetail) => {
-			if (defenceDetail.id === defence.id) {
-				defenceDetail.isActive = true;
-				defenceDetail.isTriggered = false;
-				const infoMessage = `${defence.name} defence activated`;
-				addInfoMessage(infoMessage.toLowerCase());
-			}
-			return defenceDetail;
-		});
-		setDefencesToShow(newDefenceDetails);
-	}
+	async function setDefenceToggle(defence: Defence) {
+		await toggleDefence(defence.id, defence.isActive, currentLevel);
 
-	async function setDefenceInactive(defence: Defence) {
-		await deactivateDefence(defence.id, currentLevel);
-		// update state
 		const newDefenceDetails = defencesToShow.map((defenceDetail) => {
 			if (defenceDetail.id === defence.id) {
-				defenceDetail.isActive = false;
-				defenceDetail.isTriggered = false;
-				const infoMessage = `${defence.name} defence deactivated`;
+				defenceDetail.isActive = !defence.isActive;
+				const action = defenceDetail.isActive ? 'activated' : 'deactivated';
+				const infoMessage = `${defence.name} defence ${action}`;
 				addInfoMessage(infoMessage.toLowerCase());
 			}
 			return defenceDetail;
 		});
+
 		setDefencesToShow(newDefenceDetails);
 	}
 
@@ -293,10 +278,7 @@ function MainComponent({
 					void resetDefenceConfiguration(defenceId, configId)
 				}
 				resetLevel={() => void resetLevel()}
-				setDefenceActive={(defence: Defence) => void setDefenceActive(defence)}
-				setDefenceInactive={(defence: Defence) =>
-					void setDefenceInactive(defence)
-				}
+				toggleDefence={(defence: Defence) => void setDefenceToggle(defence)}
 				setDefenceConfiguration={setDefenceConfiguration}
 				incrementNumCompletedLevels={incrementNumCompletedLevels}
 				openLevelsCompleteOverlay={openLevelsCompleteOverlay}

--- a/frontend/src/service/defenceService.ts
+++ b/frontend/src/service/defenceService.ts
@@ -16,23 +16,13 @@ async function getDefences(level: number) {
 	return (await response.json()) as Defence[];
 }
 
-async function activateDefence(
-	defenceId: string,
+async function toggleDefence(
+	defenceId: DEFENCE_ID,
+	isActive: boolean,
 	level: number
 ): Promise<boolean> {
-	const response = await sendRequest(`${PATH}activate`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ defenceId, level }),
-	});
-	return response.status === 200;
-}
-
-async function deactivateDefence(
-	defenceId: string,
-	level: number
-): Promise<boolean> {
-	const response = await sendRequest(`${PATH}deactivate`, {
+	const requestPath = isActive ? 'deactivate' : 'activate';
+	const response = await sendRequest(`${PATH}${requestPath}`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
@@ -112,8 +102,7 @@ async function resetActiveDefences(level: number) {
 
 export {
 	getDefences,
-	activateDefence,
-	deactivateDefence,
+	toggleDefence,
 	configureDefence,
 	resetDefenceConfig,
 	resetActiveDefences,


### PR DESCRIPTION
## Description

Replaces activate and deactivate functions from MainComponent, and defenceService.ts with a toggle function and pass down component heirarchy. 

## Concerns

- The original ticket mentions having the toggle logic inside the defenceService function, although I found it clearer to have MainComponent function contain the logic for setting frontend, and there is just simple logic in toggleDefence for calling the correct request URL. 

- the last functions had a line `defenceDetail.isTriggered = false`  in the setDefenceActive / setDefenceInactive functions but i didn't see a need for this so removed - unless they were there for a particular reason? 

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
