### PR TITLE
598 have themedbutton always use aria disabled over disabled

### DIFF
--- a/frontend/src/components/ThemedButtons/Loader.css
+++ b/frontend/src/components/ThemedButtons/Loader.css
@@ -1,9 +1,0 @@
-.loader {
-	position: absolute;
-	background-color: inherit;
-	width: 100%;
-	height: 100%;
-	border-radius: inherit;
-	align-items: center;
-	justify-content: center;
-}

--- a/frontend/src/components/ThemedButtons/LoadingButton.css
+++ b/frontend/src/components/ThemedButtons/LoadingButton.css
@@ -1,13 +1,9 @@
-.loading-button .themed-button {
-	height: 100%;
-}
-
-.loading-button .themed-button.disabled {
+.loading-button.themed-button.disabled {
 	background-color: var(--action-button-background-colour);
 	color: var(--action-button-text-colour);
 }
 
-.loading-button .loader {
+.loader {
 	position: absolute;
 	background-color: inherit;
 	width: 100%;

--- a/frontend/src/components/ThemedButtons/LoadingButton.css
+++ b/frontend/src/components/ThemedButtons/LoadingButton.css
@@ -1,0 +1,18 @@
+.loading-button .themed-button {
+	height: 100%;
+}
+
+.loading-button .themed-button.disabled {
+	background-color: var(--action-button-background-colour);
+	color: var(--action-button-text-colour);
+}
+
+.loading-button .loader {
+	position: absolute;
+	background-color: inherit;
+	width: 100%;
+	height: 100%;
+	border-radius: inherit;
+	align-items: center;
+	justify-content: center;
+}

--- a/frontend/src/components/ThemedButtons/LoadingButton.tsx
+++ b/frontend/src/components/ThemedButtons/LoadingButton.tsx
@@ -18,7 +18,13 @@ function LoadingButton({
 			<ThemedButton ariaDisabled={isLoading} onClick={onClick}>
 				{children}
 				{isLoading && (
-					<ThreeDots width="1.5rem" color="white" wrapperClass="loader" />
+					<ThreeDots
+						width="1.5rem"
+						color="white"
+						wrapperClass="loader"
+						// blank label as by default the label is 'three-dots-loading'
+						ariaLabel=""
+					/>
 				)}
 			</ThemedButton>
 		</div>

--- a/frontend/src/components/ThemedButtons/LoadingButton.tsx
+++ b/frontend/src/components/ThemedButtons/LoadingButton.tsx
@@ -14,20 +14,22 @@ function LoadingButton({
 	onClick: () => void;
 }) {
 	return (
-		<div className="loading-button">
-			<ThemedButton ariaDisabled={isLoading} onClick={onClick}>
-				{children}
-				{isLoading && (
-					<ThreeDots
-						width="1.5rem"
-						color="white"
-						wrapperClass="loader"
-						// blank label as by default the label is 'three-dots-loading'
-						ariaLabel=""
-					/>
-				)}
-			</ThemedButton>
-		</div>
+		<ThemedButton
+			ariaDisabled={isLoading}
+			className="loading-button"
+			onClick={onClick}
+		>
+			{children}
+			{isLoading && (
+				<ThreeDots
+					width="1.5rem"
+					color="white"
+					wrapperClass="loader"
+					// blank label as by default the label is 'three-dots-loading'
+					ariaLabel=""
+				/>
+			)}
+		</ThemedButton>
 	);
 }
 

--- a/frontend/src/components/ThemedButtons/LoadingButton.tsx
+++ b/frontend/src/components/ThemedButtons/LoadingButton.tsx
@@ -12,11 +12,7 @@ function LoadingButton({
 	isLoading?: boolean;
 }) {
 	return (
-		<ThemedButton
-			aria-disabled={isLoading}
-			appearsDifferentWhenDisabled={false}
-			{...buttonProps}
-		>
+		<ThemedButton aria-disabled={isLoading} {...buttonProps}>
 			{children}
 			{isLoading && (
 				<ThreeDots width="1.5rem" color="white" wrapperClass="loader" />

--- a/frontend/src/components/ThemedButtons/LoadingButton.tsx
+++ b/frontend/src/components/ThemedButtons/LoadingButton.tsx
@@ -13,7 +13,7 @@ function LoadingButton({
 }) {
 	return (
 		<ThemedButton
-			disabled={isLoading}
+			aria-disabled={isLoading}
 			appearsDifferentWhenDisabled={false}
 			{...buttonProps}
 		>

--- a/frontend/src/components/ThemedButtons/LoadingButton.tsx
+++ b/frontend/src/components/ThemedButtons/LoadingButton.tsx
@@ -1,23 +1,27 @@
 import { ThreeDots } from 'react-loader-spinner';
 
-import ThemedButton, { ThemedButtonProps } from './ThemedButton';
+import ThemedButton from './ThemedButton';
 
-import './Loader.css';
+import './LoadingButton.css';
 
 function LoadingButton({
 	children,
 	isLoading = false,
-	...buttonProps
-}: ThemedButtonProps & {
+	onClick,
+}: {
+	children: React.ReactNode;
 	isLoading?: boolean;
+	onClick: () => void;
 }) {
 	return (
-		<ThemedButton aria-disabled={isLoading} {...buttonProps}>
-			{children}
-			{isLoading && (
-				<ThreeDots width="1.5rem" color="white" wrapperClass="loader" />
-			)}
-		</ThemedButton>
+		<div className="loading-button">
+			<ThemedButton ariaDisabled={isLoading} onClick={onClick}>
+				{children}
+				{isLoading && (
+					<ThreeDots width="1.5rem" color="white" wrapperClass="loader" />
+				)}
+			</ThemedButton>
+		</div>
 	);
 }
 

--- a/frontend/src/components/ThemedButtons/ThemedButton.tsx
+++ b/frontend/src/components/ThemedButtons/ThemedButton.tsx
@@ -7,6 +7,7 @@ export interface ThemedButtonProps {
 	children: ReactNode;
 	ariaDisabled?: boolean;
 	ariaLabel?: string;
+	className?: string;
 	title?: string;
 	onClick: () => void;
 }
@@ -15,6 +16,7 @@ function ThemedButton({
 	children,
 	ariaDisabled = false,
 	ariaLabel,
+	className,
 	title,
 	onClick,
 }: ThemedButtonProps) {
@@ -22,7 +24,7 @@ function ThemedButton({
 		if (!ariaDisabled) onClick();
 	}
 
-	const buttonClass = clsx('themed-button', {
+	const buttonClass = clsx('themed-button', className, {
 		disabled: ariaDisabled,
 	});
 

--- a/frontend/src/components/ThemedButtons/ThemedButton.tsx
+++ b/frontend/src/components/ThemedButtons/ThemedButton.tsx
@@ -5,7 +5,6 @@ import './ThemedButton.css';
 
 export interface ThemedButtonProps {
 	children: ReactNode;
-	appearsDifferentWhenDisabled?: boolean;
 	ariaDisabled?: boolean;
 	ariaLabel?: string;
 	title?: string;
@@ -14,7 +13,6 @@ export interface ThemedButtonProps {
 
 function ThemedButton({
 	children,
-	appearsDifferentWhenDisabled = true,
 	ariaDisabled = false,
 	ariaLabel,
 	title,
@@ -25,7 +23,7 @@ function ThemedButton({
 	}
 
 	const buttonClass = clsx('themed-button', {
-		disabled: appearsDifferentWhenDisabled && ariaDisabled,
+		disabled: ariaDisabled,
 	});
 
 	return (

--- a/frontend/src/components/ThemedButtons/ThemedButton.tsx
+++ b/frontend/src/components/ThemedButtons/ThemedButton.tsx
@@ -8,7 +8,6 @@ export interface ThemedButtonProps {
 	appearsDifferentWhenDisabled?: boolean;
 	ariaDisabled?: boolean;
 	ariaLabel?: string;
-	disabled?: boolean;
 	title?: string;
 	onClick: () => void;
 }
@@ -18,16 +17,15 @@ function ThemedButton({
 	appearsDifferentWhenDisabled = true,
 	ariaDisabled = false,
 	ariaLabel,
-	disabled = false,
 	title,
 	onClick,
 }: ThemedButtonProps) {
 	function onClickDisabledCheck() {
-		if (!disabled && !ariaDisabled) onClick();
+		if (!ariaDisabled) onClick();
 	}
 
 	const buttonClass = clsx('themed-button', {
-		disabled: appearsDifferentWhenDisabled && (disabled || ariaDisabled),
+		disabled: appearsDifferentWhenDisabled && ariaDisabled,
 	});
 
 	return (
@@ -36,7 +34,6 @@ function ThemedButton({
 			onClick={onClickDisabledCheck}
 			aria-disabled={ariaDisabled}
 			aria-label={ariaLabel}
-			disabled={disabled}
 			title={title}
 		>
 			{children}


### PR DESCRIPTION
## Description

The ThemedButton component now only uses `aria-disabled` rather than `disabled`.

## Notes

- Also removed the `appearsDifferentWhenDisabled` from the component.
- Wrapped the LoadingButton component in a new `div` in order to overwrite the disabled styling on the child ThemedButton.
- Actually fixed a bug where the LoadingButton wasn't being disabled at all due to a typo in the `ariaDisabled` prop name (it was `aria-disabled`).
- Simplified the LoadingButton props.
- There was a default label on the spinner inside the LoadingButton that made it quite odd when it was being read out by a screen reader. The label was "three-dots-loading". The screen reader said something along the lines of "send three dots loading button disabled". Which I thought was clunky so I removed the label, so now it says "send button disabled".

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
