### PR TITLE
fix bot blocked position on export log

### DIFF
--- a/frontend/src/components/ExportChat/ExportChatMessage.tsx
+++ b/frontend/src/components/ExportChat/ExportChatMessage.tsx
@@ -55,8 +55,9 @@ function getFullPrefix(message: ChatMessage) {
 		case CHAT_MESSAGE_TYPE.ERROR_MSG:
 			return `Error: ${message.message}`;
 		case CHAT_MESSAGE_TYPE.BOT:
-		case CHAT_MESSAGE_TYPE.BOT_BLOCKED:
 			return `Bot: ${message.message}`;
+		case CHAT_MESSAGE_TYPE.BOT_BLOCKED:
+			return `Bot (blocked): ${message.message}`;
 		default:
 			return message.message;
 	}
@@ -71,6 +72,7 @@ function getMessageStyle(type: CHAT_MESSAGE_TYPE) {
 			return styles.chatBoxInfo;
 		case CHAT_MESSAGE_TYPE.USER:
 			return styles.chatBoxMessage;
+		case CHAT_MESSAGE_TYPE.BOT_BLOCKED:
 		case CHAT_MESSAGE_TYPE.BOT:
 			return styles.chatBoxMessageBot;
 		case CHAT_MESSAGE_TYPE.LEVEL_INFO:


### PR DESCRIPTION
## Description

Missed out BOT_BLOCKED in getMessageStyle case stmt. 🤷‍♂️ Also added a wee Bot (blocked): for clarity:


## Screenshots

![image](https://github.com/ScottLogic/prompt-injection/assets/118981273/1c543b8a-838d-4504-b798-c85e91e4ff01)

## Notes

- Bullet point list with
- any notable code changes
- or explanations regarding this PR

## Concerns

- Bullet point list
- with any questions
- or concerns about this PR

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
