### PR TITLE
716 visibly hidden h1 added

### DIFF
--- a/frontend/src/components/MainComponent/MainHeader.tsx
+++ b/frontend/src/components/MainComponent/MainHeader.tsx
@@ -36,6 +36,7 @@ function MainHeader({
 					}
 					alt="Spy Logic"
 				/>
+				<h1 className="visually-hidden">Spy Logic</h1>
 			</span>
 			<span className="main-header-middle">
 				<span className="main-header-level">Level</span>


### PR DESCRIPTION
## Description
Visibly hidden h1 right after the logo image to preserve correct heading structure.

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
