### PR TITLE
704 refactor detecttriggereddefences to remove mutation

### DIFF
--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -223,6 +223,14 @@ async function detectTriggeredDefences(message: string, defences: Defence[]) {
 
 	return defenceReport;
 }
+function getEmptyChatDefenceReport(): ChatDefenceReport {
+	return {
+		blockedReason: null,
+		isBlocked: false,
+		alertedDefences: [],
+		triggeredDefences: [],
+	};
+}
 
 function detectCharacterLimit(
 	defenceReport: ChatDefenceReport,
@@ -230,7 +238,7 @@ function detectCharacterLimit(
 	defences: Defence[]
 ) {
 	const maxMessageLength = Number(getMaxMessageLength(defences));
-	// check if the message is too long
+
 	if (message.length > maxMessageLength) {
 		console.debug('CHARACTER_LIMIT defence triggered.');
 		// check if the defence is active
@@ -244,8 +252,10 @@ function detectCharacterLimit(
 			// add the defence to the list of alerted defences
 			defenceReport.alertedDefences.push(DEFENCE_ID.CHARACTER_LIMIT);
 		}
+		return defenceReport;
+	} else {
+		return getEmptyChatDefenceReport();
 	}
-	return defenceReport;
 }
 
 function detectFilterUserInput(

--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -268,31 +268,35 @@ function detectFilterUserInput(
 		message,
 		getFilterList(defences, DEFENCE_ID.FILTER_USER_INPUT)
 	);
-	if (detectedPhrases.length > 0) {
+
+	const filterWordsDetected = detectedPhrases.length > 0;
+	const defenceActive = isDefenceActive(DEFENCE_ID.FILTER_USER_INPUT, defences);
+
+	if (filterWordsDetected) {
 		console.debug(
 			`FILTER_USER_INPUT defence triggered. Detected phrases from blocklist: ${detectedPhrases.join(
 				', '
 			)}`
 		);
-		if (isDefenceActive(DEFENCE_ID.FILTER_USER_INPUT, defences)) {
-			return {
+	}
+
+	return filterWordsDetected && defenceActive
+		? {
 				blockedReason: `Message blocked - I cannot answer questions about '${detectedPhrases.join(
 					"' or '"
 				)}'!`,
 				isBlocked: true,
 				alertedDefences: [],
 				triggeredDefences: [DEFENCE_ID.FILTER_USER_INPUT],
-			};
-		} else {
-			return {
+		  }
+		: filterWordsDetected && !defenceActive
+		? {
 				blockedReason: null,
 				isBlocked: false,
 				alertedDefences: [DEFENCE_ID.FILTER_USER_INPUT],
 				triggeredDefences: [],
-			};
-		}
-	}
-	return getEmptyChatDefenceReport();
+		  }
+		: getEmptyChatDefenceReport();
 }
 
 function detectXmlTagging(

--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -276,10 +276,8 @@ function detectCharacterLimit(
 		  }
 		: messageExceedsLimit && !defenceActive
 		? {
-				blockedReason: null,
-				isBlocked: false,
+				...getEmptyChatDefenceReport(),
 				alertedDefences: [DEFENCE_ID.CHARACTER_LIMIT],
-				triggeredDefences: [],
 		  }
 		: getEmptyChatDefenceReport();
 }
@@ -315,10 +313,8 @@ function detectFilterUserInput(
 		  }
 		: filterWordsDetected && !defenceActive
 		? {
-				blockedReason: null,
-				isBlocked: false,
+				...getEmptyChatDefenceReport(),
 				alertedDefences: [DEFENCE_ID.FILTER_USER_INPUT],
-				triggeredDefences: [],
 		  }
 		: getEmptyChatDefenceReport();
 }

--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -214,13 +214,16 @@ async function detectTriggeredDefences(message: string, defences: Defence[]) {
 	const characterLimitDefenceReport = detectCharacterLimit(message, defences);
 	const filterUserInputDefenceReport = detectFilterUserInput(message, defences);
 	const xmlTaggingDefenceReport = detectXmlTagging(message, defences);
-	const evaluationDefenceReport = await detectEvaluationLLM(message, defences);
+	const evaluationLLMDefenceReport = await detectEvaluationLLM(
+		message,
+		defences
+	);
 
 	return combineDefenceReports([
 		characterLimitDefenceReport,
 		filterUserInputDefenceReport,
 		xmlTaggingDefenceReport,
-		evaluationDefenceReport,
+		evaluationLLMDefenceReport,
 	]);
 }
 

--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -351,12 +351,12 @@ async function detectEvaluationLLM(
 	if (isDefenceActive(DEFENCE_ID.PROMPT_EVALUATION_LLM, defences)) {
 		const promptEvalLLMPrompt = getPromptEvalPromptFromConfig(defences);
 
-		const evalPrompt = await queryPromptEvaluationModel(
+		const evaluationResult = await queryPromptEvaluationModel(
 			message,
 			promptEvalLLMPrompt
 		);
 
-		if (evalPrompt.isMalicious) {
+		if (evaluationResult.isMalicious) {
 			console.debug('LLM evaluation defence active and prompt is malicious.');
 
 			return {

--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -238,10 +238,13 @@ function detectCharacterLimit(
 ): ChatDefenceReport {
 	const maxMessageLength = Number(getMaxMessageLength(defences));
 
-	if (message.length > maxMessageLength) {
+	const messageExceedsLimit = message.length > maxMessageLength;
+	const defenceActive = isDefenceActive(DEFENCE_ID.CHARACTER_LIMIT, defences);
+
+	if (messageExceedsLimit) {
 		console.debug('CHARACTER_LIMIT defence triggered.');
 		// check if the defence is active
-		if (isDefenceActive(DEFENCE_ID.CHARACTER_LIMIT, defences)) {
+		if (defenceActive) {
 			return {
 				blockedReason: 'Message is too long',
 				isBlocked: true,

--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -218,7 +218,7 @@ async function detectTriggeredDefences(message: string, defences: Defence[]) {
 	// the following methods will add triggered defences to the defenceReport
 	const characterLimitDefenceReport = detectCharacterLimit(message, defences);
 	const filterUserInputDefenceReport = detectFilterUserInput(message, defences);
-	detectXmlTagging(defenceReport, message, defences);
+	const xmlTaggingDefenceReport = detectXmlTagging(message, defences);
 	await detectEvaluationLLM(defenceReport, message, defences);
 
 	return defenceReport;
@@ -300,22 +300,24 @@ function detectFilterUserInput(
 }
 
 function detectXmlTagging(
-	defenceReport: ChatDefenceReport,
 	message: string,
 	defences: Defence[]
-) {
-	// check if message contains XML tags
+): ChatDefenceReport {
 	if (containsXMLTags(message)) {
 		console.debug('XML_TAGGING defence triggered.');
 		if (isDefenceActive(DEFENCE_ID.XML_TAGGING, defences)) {
-			// add the defence to the list of triggered defences
-			defenceReport.triggeredDefences.push(DEFENCE_ID.XML_TAGGING);
+			return {
+				...getEmptyChatDefenceReport(),
+				triggeredDefences: [DEFENCE_ID.XML_TAGGING],
+			};
 		} else {
-			// add the defence to the list of alerted defences
-			defenceReport.alertedDefences.push(DEFENCE_ID.XML_TAGGING);
+			return {
+				...getEmptyChatDefenceReport(),
+				alertedDefences: [DEFENCE_ID.XML_TAGGING],
+			};
 		}
 	}
-	return defenceReport;
+	return getEmptyChatDefenceReport();
 }
 
 async function detectEvaluationLLM(

--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -216,7 +216,7 @@ async function detectTriggeredDefences(message: string, defences: Defence[]) {
 	};
 
 	// the following methods will add triggered defences to the defenceReport
-	detectCharacterLimit(defenceReport, message, defences);
+	const characterLimitDefenceReport = detectCharacterLimit(message, defences);
 	detectFilterUserInput(defenceReport, message, defences);
 	detectXmlTagging(defenceReport, message, defences);
 	await detectEvaluationLLM(defenceReport, message, defences);
@@ -233,26 +233,29 @@ function getEmptyChatDefenceReport(): ChatDefenceReport {
 }
 
 function detectCharacterLimit(
-	defenceReport: ChatDefenceReport,
 	message: string,
 	defences: Defence[]
-) {
+): ChatDefenceReport {
 	const maxMessageLength = Number(getMaxMessageLength(defences));
 
 	if (message.length > maxMessageLength) {
 		console.debug('CHARACTER_LIMIT defence triggered.');
 		// check if the defence is active
 		if (isDefenceActive(DEFENCE_ID.CHARACTER_LIMIT, defences)) {
-			// add the defence to the list of triggered defences
-			defenceReport.triggeredDefences.push(DEFENCE_ID.CHARACTER_LIMIT);
-			// block the message
-			defenceReport.isBlocked = true;
-			defenceReport.blockedReason = 'Message is too long';
+			return {
+				blockedReason: 'Message is too long',
+				isBlocked: true,
+				alertedDefences: [],
+				triggeredDefences: [DEFENCE_ID.CHARACTER_LIMIT],
+			};
 		} else {
-			// add the defence to the list of alerted defences
-			defenceReport.alertedDefences.push(DEFENCE_ID.CHARACTER_LIMIT);
+			return {
+				blockedReason: null,
+				isBlocked: false,
+				alertedDefences: [DEFENCE_ID.CHARACTER_LIMIT],
+				triggeredDefences: [],
+			};
 		}
-		return defenceReport;
 	} else {
 		return getEmptyChatDefenceReport();
 	}

--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -241,27 +241,23 @@ function detectCharacterLimit(
 	const messageExceedsLimit = message.length > maxMessageLength;
 	const defenceActive = isDefenceActive(DEFENCE_ID.CHARACTER_LIMIT, defences);
 
-	if (messageExceedsLimit) {
-		console.debug('CHARACTER_LIMIT defence triggered.');
-		// check if the defence is active
-		if (defenceActive) {
-			return {
+	if (messageExceedsLimit) console.debug('CHARACTER_LIMIT defence triggered.');
+
+	return messageExceedsLimit && defenceActive
+		? {
 				blockedReason: 'Message is too long',
 				isBlocked: true,
 				alertedDefences: [],
 				triggeredDefences: [DEFENCE_ID.CHARACTER_LIMIT],
-			};
-		} else {
-			return {
+		  }
+		: messageExceedsLimit && !defenceActive
+		? {
 				blockedReason: null,
 				isBlocked: false,
 				alertedDefences: [DEFENCE_ID.CHARACTER_LIMIT],
 				triggeredDefences: [],
-			};
-		}
-	} else {
-		return getEmptyChatDefenceReport();
-	}
+		  }
+		: getEmptyChatDefenceReport();
 }
 
 function detectFilterUserInput(

--- a/backend/src/defence.ts
+++ b/backend/src/defence.ts
@@ -303,21 +303,24 @@ function detectXmlTagging(
 	message: string,
 	defences: Defence[]
 ): ChatDefenceReport {
-	if (containsXMLTags(message)) {
+	const containsXML = containsXMLTags(message);
+	const defenceActive = isDefenceActive(DEFENCE_ID.XML_TAGGING, defences);
+
+	if (containsXML) {
 		console.debug('XML_TAGGING defence triggered.');
-		if (isDefenceActive(DEFENCE_ID.XML_TAGGING, defences)) {
-			return {
+	}
+
+	return containsXML && defenceActive
+		? {
 				...getEmptyChatDefenceReport(),
 				triggeredDefences: [DEFENCE_ID.XML_TAGGING],
-			};
-		} else {
-			return {
+		  }
+		: containsXML && !defenceActive
+		? {
 				...getEmptyChatDefenceReport(),
 				alertedDefences: [DEFENCE_ID.XML_TAGGING],
-			};
-		}
-	}
-	return getEmptyChatDefenceReport();
+		  }
+		: getEmptyChatDefenceReport();
 }
 
 async function detectEvaluationLLM(

--- a/backend/src/models/chat.ts
+++ b/backend/src/models/chat.ts
@@ -55,6 +55,7 @@ interface ChatDefenceReport {
 }
 
 interface SingleDefenceReport {
+	defence: DEFENCE_ID;
 	blockedReason: string | null;
 	status: 'alerted' | 'triggered' | 'ok';
 }

--- a/backend/src/models/chat.ts
+++ b/backend/src/models/chat.ts
@@ -54,6 +54,11 @@ interface ChatDefenceReport {
 	triggeredDefences: DEFENCE_ID[];
 }
 
+interface SingleDefenceReport {
+	blockedReason: string | null;
+	status: 'alerted' | 'triggered' | 'ok';
+}
+
 interface ChatAnswer {
 	reply: string;
 	questionAnswered: boolean;
@@ -121,4 +126,5 @@ export {
 	ChatModel,
 	ChatModelConfiguration,
 	defaultChatModel,
+	SingleDefenceReport,
 };


### PR DESCRIPTION
## Description

r-r-refactor, y'all 🏭
specifically, killing the mutants 🔫

## Notes

as the ticket says, `detectTriggeredDefences()` now follows this structure:
```typescript
const xmlDefenceRep = detectXmlDefence(...)
const promptEvalRep = detectPromptEvalDefence(...)
...
return combineReports(xmlDefenceRep, promptEvalRep, ...)
```

And each the detection method for each defence no longer mutates anything.

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
