### PR TITLE
651-dont-export-methods-just-for-testing-openaits

### DIFF
--- a/backend/src/openai.ts
+++ b/backend/src/openai.ts
@@ -550,7 +550,6 @@ export const getValidOpenAIModelsList = validOpenAiModels.get;
 export {
 	chatGptTools,
 	chatGptSendMessage,
-	filterChatHistoryByMaxTokens,
 	getOpenAIKey,
 	getValidModelsFromOpenAI,
 };


### PR DESCRIPTION
## Description

only removes one export: `filterChatHistoryByMaxTokens`, which was just being imported from the token utils file only to be re-exported. None of the tests relied on this specific export. All other exports are imported and used in other backend files.

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
