### PR TITLE
637 Not underlining the '|' on hover in the footer

### DIFF
--- a/frontend/src/components/MainComponent/MainFooter.css
+++ b/frontend/src/components/MainComponent/MainFooter.css
@@ -32,6 +32,7 @@
 }
 
 .main-footer .links a:not(:last-child)::after {
+	display: inline-block;
 	content: '|';
 	padding: 0 0.75rem;
 }


### PR DESCRIPTION
## Description

The '|' separator in the footer is no longer being underlined on hover.

## Screenshots

![image](https://github.com/ScottLogic/prompt-injection/assets/103250539/6c69e7b3-611f-4448-96bc-df0165399442)

## Notes

- Wish I could claim this big brain move 🧠 but I found the solution [here](https://stackoverflow.com/questions/1238881/text-decoration-and-the-after-pseudo-element-revisited)

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
