### PR TITLE
598 add tooltips to disabled buttons

### DIFF
--- a/frontend/src/components/ChatBox/ChatBox.tsx
+++ b/frontend/src/components/ChatBox/ChatBox.tsx
@@ -222,6 +222,7 @@ function ChatBox({
 						<LoadingButton
 							onClick={() => void sendChatMessage()}
 							isLoading={isSendingMessage}
+							loadingTooltip="Sending message..."
 						>
 							send
 						</LoadingButton>

--- a/frontend/src/components/LevelSelectionBox/LevelSelectionBox.tsx
+++ b/frontend/src/components/LevelSelectionBox/LevelSelectionBox.tsx
@@ -25,20 +25,25 @@ function LevelSelectionBox({
 			setCurrentLevel(newLevel);
 		}
 	}
+
 	return (
 		<div className="level-selection-box">
 			{displayLevels.map(({ id, displayName }, index) => {
+				const disabled =
+					index > numCompletedLevels && id !== LEVEL_NAMES.SANDBOX;
 				return (
 					<LevelButton
 						key={id}
 						onClick={() => {
 							handleLevelChange(id);
 						}}
-						disabled={index > numCompletedLevels && id !== LEVEL_NAMES.SANDBOX}
+						disabled={disabled}
 						selected={id === currentLevel}
 						ariaLabel={
 							id === LEVEL_NAMES.SANDBOX ? undefined : `Level ${displayName}`
 						}
+						// show tooltip if the button is disabled
+						title={disabled ? `Complete level ${index} to unlock` : undefined}
 					>
 						{displayName}
 					</LevelButton>

--- a/frontend/src/components/ModelBox/ModelSelection.tsx
+++ b/frontend/src/components/ModelBox/ModelSelection.tsx
@@ -70,6 +70,7 @@ function ModelSelection({ chatModelOptions }: { chatModelOptions: string[] }) {
 					<LoadingButton
 						onClick={() => void submitSelectedModel()}
 						isLoading={isSettingModel}
+						loadingTooltip="Changing model..."
 					>
 						Choose
 					</LoadingButton>

--- a/frontend/src/components/ThemedButtons/LevelButton.tsx
+++ b/frontend/src/components/ThemedButtons/LevelButton.tsx
@@ -8,6 +8,7 @@ export interface LevelButtonProps {
 	disabled?: boolean;
 	selected?: boolean;
 	ariaLabel?: string;
+	title?: string;
 	onClick: () => void;
 }
 
@@ -16,6 +17,7 @@ function LevelButton({
 	disabled = false,
 	selected = false,
 	ariaLabel,
+	title,
 	onClick,
 }: LevelButtonProps) {
 	const buttonProps = {
@@ -27,6 +29,7 @@ function LevelButton({
 		},
 		'aria-disabled': disabled,
 		'aria-label': ariaLabel,
+		title,
 	};
 
 	return <button {...buttonProps}>{children}</button>;

--- a/frontend/src/components/ThemedButtons/LoadingButton.tsx
+++ b/frontend/src/components/ThemedButtons/LoadingButton.tsx
@@ -16,6 +16,8 @@ function LoadingButton({
 	return (
 		<ThemedButton
 			ariaDisabled={isLoading}
+			// tooltip is shown when button is disabled
+			title={isLoading ? 'Loading' : undefined}
 			className="loading-button"
 			onClick={onClick}
 		>

--- a/frontend/src/components/ThemedButtons/LoadingButton.tsx
+++ b/frontend/src/components/ThemedButtons/LoadingButton.tsx
@@ -7,17 +7,19 @@ import './LoadingButton.css';
 function LoadingButton({
 	children,
 	isLoading = false,
+	loadingTooltip,
 	onClick,
 }: {
 	children: React.ReactNode;
 	isLoading?: boolean;
+	loadingTooltip?: string;
 	onClick: () => void;
 }) {
 	return (
 		<ThemedButton
 			ariaDisabled={isLoading}
 			// tooltip is shown when button is disabled
-			title={isLoading ? 'Loading' : undefined}
+			title={isLoading ? loadingTooltip : undefined}
 			className="loading-button"
 			onClick={onClick}
 		>


### PR DESCRIPTION
## Description

Adding tooltips (titles) to various buttons when they're disabled.

## Screenshots

Level buttons (hovering over level 2):

![image](https://github.com/ScottLogic/prompt-injection/assets/103250539/4516fcad-6318-4f00-bbfd-f2a4220d9a12)

Send button: 

![image](https://github.com/ScottLogic/prompt-injection/assets/103250539/6704098f-780a-4495-bd11-53a57addd28b)

Model change:

![image](https://github.com/ScottLogic/prompt-injection/assets/103250539/374dd259-7551-4aa2-b4d7-b8b24621e19f)

## Notes

- The level select buttons aren't actually ThemedButtons anymore, but this was easy enough to add in.

## Concerns

- Before, the `LevelButton` component didn't have a `title`, but did have an `aria-label`. Now, we have an `aria-label` that is not the same as the `title` when the button is disabled. Is this acceptable?
- Before, the `LoadingButton` component didn't have either a `title` or an `aria-label`. Should add an `aria-label` as well when the button is disabled?
- There can also be disabled buttons in the document viewer. For example, when the first document is displayed, the previous document button is disabled. I didn't add tooltips for these as I thought it was clear why they would be disabled, but happy to add them in if necessary. 

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
