### PR TITLE
710 reset defences for sandbox and reword modal warning

### DIFF
--- a/backend/src/controller/resetController.ts
+++ b/backend/src/controller/resetController.ts
@@ -1,14 +1,10 @@
 import { Request, Response } from 'express';
 
-import { LEVEL_NAMES, levelsInitialState } from '@src/models/level';
+import { levelsInitialState } from '@src/models/level';
 
 function handleResetProgress(req: Request, res: Response) {
 	console.debug('Resetting progress for all levels', req.session.levelState);
-	// keep track of sandbox state to preserve defences
-	const sandboxDefenceState =
-		req.session.levelState[LEVEL_NAMES.SANDBOX].defences;
-	req.session.levelState = { ...levelsInitialState };
-	req.session.levelState[LEVEL_NAMES.SANDBOX].defences = sandboxDefenceState;
+	req.session.levelState = levelsInitialState;
 	res.send(req.session.levelState);
 }
 

--- a/backend/test/unit/controller/resetController.test.ts
+++ b/backend/test/unit/controller/resetController.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@src/models/chat';
 import { DEFENCE_ID, Defence, DefenceConfigItem } from '@src/models/defence';
 import { EmailInfo } from '@src/models/email';
-import { LEVEL_NAMES, LevelState } from '@src/models/level';
+import { LEVEL_NAMES, LevelState, levelsInitialState } from '@src/models/level';
 
 declare module 'express-session' {
 	interface Session {
@@ -66,32 +66,27 @@ describe('handleResetAllDefences unit tests', () => {
 			},
 		} as unknown as Request;
 
-		// empty chat history
-		const expectedLevelState = createLevelObject('chatHistory', []);
-
 		const res = responseMock();
 		handleResetProgress(reqWithChatHistory, res);
-		expect(res.send).toHaveBeenCalledWith(expectedLevelState);
+		expect(res.send).toHaveBeenCalledWith(levelsInitialState);
 	});
 
 	test('GIVEN sent emails THEN should reset emails for all levels', () => {
 		const mockSentEmails: EmailInfo[] = [
 			{ address: 'bob@example.com', subject: 'test', body: 'this is a test' },
 		];
-
 		const reqWithSentEmails = {
 			session: {
 				levelState: createLevelObject('sentEmails', mockSentEmails),
 			},
 		} as unknown as Request;
 
-		const expectedLevelState = createLevelObject('sentEmails', []);
 		const res = responseMock();
 		handleResetProgress(reqWithSentEmails, res);
-		expect(res.send).toHaveBeenCalledWith(expectedLevelState);
+		expect(res.send).toHaveBeenCalledWith(levelsInitialState);
 	});
 
-	test('GIVEN defences THEN should reset defences for levels but not sandbox', () => {
+	test('GIVEN defences THEN should reset defences for levels', () => {
 		function configureAndActivateDefence(
 			id: DEFENCE_ID,
 			defences: Defence[],
@@ -112,33 +107,14 @@ describe('handleResetAllDefences unit tests', () => {
 				},
 			]
 		);
-
 		const reqWithDefences = {
 			session: {
 				levelState: createLevelObject('defences', mockDefences),
 			},
 		} as unknown as Request;
 
-		const expectedLevelState: Record<string, LevelState> = createLevelObject(
-			'defences',
-			defaultDefences
-		);
-
-		// update sandbox as this should not be reset
-		const resetSandbox = configureAndActivateDefence(
-			DEFENCE_ID.CHARACTER_LIMIT,
-			expectedLevelState[LEVEL_NAMES.SANDBOX].defences,
-			[
-				{
-					id: 'MAX_MESSAGE_LENGTH',
-					value: '10',
-				},
-			]
-		);
-		expectedLevelState[LEVEL_NAMES.SANDBOX].defences = resetSandbox;
-
 		const res = responseMock();
 		handleResetProgress(reqWithDefences, res);
-		expect(res.send).toHaveBeenCalledWith(expectedLevelState);
+		expect(res.send).toHaveBeenCalledWith(levelsInitialState);
 	});
 });

--- a/backend/test/unit/controller/resetController.test.ts
+++ b/backend/test/unit/controller/resetController.test.ts
@@ -49,7 +49,7 @@ function createLevelObject(
 	return obj;
 }
 
-describe('handleResetAllDefences unit tests', () => {
+describe('handleResetProgress unit tests', () => {
 	test('GIVEN a chat history THEN should reset all chatHistory for all levels', () => {
 		const mockChatHistory: ChatHistoryMessage[] = [
 			{

--- a/frontend/src/components/Overlay/ResetProgress.tsx
+++ b/frontend/src/components/Overlay/ResetProgress.tsx
@@ -24,8 +24,7 @@ function ResetProgressOverlay({
 					<h1> Reset all progress </h1>
 					<p>
 						{`Warning! This will reset all your progress in the levels and sandbox mode. 
-							This includes all your conversation history and sent emails. 
-							However any configurations you have made to defences in sandbox mode will not be lost.
+							This includes all your conversation history and sent emails. Any configurations you have made to defences in sandbox mode will also be lost.
 							Are you sure you want to do this?`}
 					</p>
 				</>


### PR DESCRIPTION
## Description

Remove the part that saves sandbox defences from control & warn the user in the modal.

## Screenshots

![image](https://github.com/ScottLogic/prompt-injection/assets/118981273/617024e9-4a80-4465-ba4e-f8e2631abbce)

## Notes

- Bullet point list with
- any notable code changes
- or explanations regarding this PR

## Concerns

- Bullet point list
- with any questions
- or concerns about this PR

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [x] Added tests
- [x] Ensured the workflow steps are passing
