### PR TITLE
725 Toggle button and defence config restyle

### DIFF
--- a/frontend/src/Theme.css
+++ b/frontend/src/Theme.css
@@ -15,6 +15,7 @@
 	--main-border-colour: #666;
 	--main-text-colour: #fff;
 	--main-text-colour-inverted: #000;
+	--main-text-accent-colour: #73d1d6;
 	--error-colour: #c41565;
 
 	/* scrollbar */

--- a/frontend/src/Theme.css
+++ b/frontend/src/Theme.css
@@ -49,7 +49,7 @@
 
 	/* toggle switch */
 	--main-toggle-ball-colour: #ececec;
-	--main-toggle-off-border-colour: #aaaaaa;
+	--main-toggle-off-border-colour: #aaa;
 	--main-toggle-off-colour: transparent;
 	--main-toggle-on-border-colour: var(--accent-colour);
 	--main-toggle-on-colour: var(--accent-colour);

--- a/frontend/src/Theme.css
+++ b/frontend/src/Theme.css
@@ -48,7 +48,7 @@
 
 	/* toggle switch */
 	--main-toggle-ball-colour: #ececec;
-	--main-toggle-off-border-colour: var(--level-button-border-colour-disabled);
+	--main-toggle-off-border-colour: #aaaaaa;
 	--main-toggle-off-colour: transparent;
 	--main-toggle-on-border-colour: var(--accent-colour);
 	--main-toggle-on-colour: var(--accent-colour);
@@ -56,6 +56,7 @@
 	/* control panel */
 	--control-header-background-colour: #313131;
 	--control-body-background-colour: #3a3a3a;
+	--control-config-border: var(--chat-info-text-colour);
 
 	/* general modal overlay */
 	--overlay-background-colour: #8ad5da;

--- a/frontend/src/components/DefenceBox/DefenceMechanism.css
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.css
@@ -18,9 +18,8 @@
 	border-radius: 0.25rem;
 }
 
-/* style for when details element is expanded */
-.defence-mechanism-fieldset details[open] > summary {
-	border-style: inset;
+.defence-mechanism > summary {
+	font-size: 1rem;
 }
 
 /* remove the default triangle on the summary element */
@@ -32,6 +31,11 @@
 	display: none;
 }
 
+/* style for when details element is expanded */
+.defence-mechanism-fieldset details[open] > summary {
+	border-style: inset;
+}
+
 /* the toggle and label combined */
 .defence-mechanism-form {
 	position: absolute;
@@ -40,14 +44,6 @@
 
 .defence-mechanism {
 	cursor: default;
-}
-
-.defence-mechanism > summary {
-	font-size: 1rem;
-}
-
-.defence-mechanism .info-box {
-	font-size: 0.875rem;
 }
 
 .defence-mechanism .info-box :first-child {
@@ -98,31 +94,18 @@
 	text-align: right;
 }
 
-/* the  label hovered or focused */
-.toggles [type='checkbox']:focus + label,
-.toggles [type='checkbox']:hover + label {
-	color: var(--main-text-accent-colour);
-}
-
-.toggles [type='checkbox']:focus + label::before,
-.toggles [type='checkbox']:hover + label::before {
-	box-shadow: 0 0 0.3em var(--main-text-colour);
-}
-
-.toggles [type='checkbox']:focus + label::after,
-.toggles [type='checkbox']:hover + label::after {
-	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50' cy='50' r='50' fill='rgba(0,0,0,.25)'/%3E%3C/svg%3E");
-	background-position: center center;
-	background-size: 30%;
-	background-repeat: no-repeat;
-}
-
 .toggles [type='checkbox'] + label::before,
 .toggles [type='checkbox'] + label::after {
 	content: '';
 	position: absolute;
 	height: 0.9em;
 	transition: all 0.25s ease;
+}
+
+/* the  label hovered or focused */
+.toggles [type='checkbox']:focus + label,
+.toggles [type='checkbox']:hover + label {
+	color: var(--main-text-accent-colour);
 }
 
 /* background oval before it's checked */
@@ -144,6 +127,19 @@
 	border-radius: 50%;
 	background: var(--main-text-colour);
 	background-position: center center;
+}
+
+.toggles [type='checkbox']:focus + label::before,
+.toggles [type='checkbox']:hover + label::before {
+	box-shadow: 0 0 0.3em var(--main-text-colour);
+}
+
+.toggles [type='checkbox']:focus + label::after,
+.toggles [type='checkbox']:hover + label::after {
+	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50' cy='50' r='50' fill='rgba(0,0,0,.25)'/%3E%3C/svg%3E");
+	background-position: center center;
+	background-size: 30%;
+	background-repeat: no-repeat;
 }
 
 /* round toggle slider sliding to the right */

--- a/frontend/src/components/DefenceBox/DefenceMechanism.css
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.css
@@ -41,10 +41,6 @@
 	cursor: default;
 }
 
-/* .defence-mechanism > * {
-	padding: 0.75rem;
-} */
-
 .defence-mechanism > summary {
 	font-size: 1rem;
 }
@@ -53,9 +49,9 @@
 	font-size: 0.875rem;
 }
 
-/* .defence-mechanism .info-box :first-child {
+.defence-mechanism .info-box :first-child {
 	margin-top: 0;
-} */
+}
 
 /* the expanded description and further controls */
 .defence-mechanism .info-box {
@@ -160,18 +156,6 @@
 .toggles [type='checkbox']:checked + label::before {
 	background-color: var(--main-toggle-on-border-colour);
 	border-color: var(--main-toggle-on-border-colour);
-}
-
-/* Windows High Contrast Mode Support */
-@media screen and (-ms-high-contrast: active) {
-	.toggles [type='checkbox']:focus + label::before,
-	.toggles [type='checkbox']:hover + label::before {
-		outline: 1px dotted windowText;
-		outline-offset: 0.25em;
-	}
-	.toggles [type='checkbox'] + label::after {
-		background-color: windowText;
-	}
 }
 
 /* Reduced motion */

--- a/frontend/src/components/DefenceBox/DefenceMechanism.css
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.css
@@ -1,92 +1,66 @@
+.defence-mechanism-fieldset {
+	border: 0.25rem solid var(--control-config-border);
+	border-radius: 0.5rem;
+	margin: 0.1em;
+	min-height: fit-content;
+}
+
+/* the name of the fieldset */
+.defence-mechanism-legend {
+	padding: 0.3em;
+}
+
+/* the more button to expand the details */
+.defence-mechanism-summary {
+	width: fit-content;
+	border: 0.125rem outset var(--control-config-border);
+	border-radius: 0.25rem;
+	padding: 0.5rem;
+}
+
+/* style for when details element is expanded */
+.defence-mechanism-fieldset details[open] > summary {
+	border-style: inset;
+}
+
+/* remove the default triangle on the summary element*/
+.defence-mechanism-fieldset details > summary {
+	list-style: none;
+}
+.defence-mechanism-fieldset details > summary::-webkit-details-marker {
+	display: none;
+}
+
+/* the toggle and label combined */
+.defence-mechanism-form {
+	position: absolute;
+	right: 1em;
+}
+
 .defence-mechanism {
 	cursor: default;
 }
 
-.defence-mechanism > * {
+/* .defence-mechanism > * {
 	padding: 0.75rem;
-}
+} */
 
 .defence-mechanism > summary {
-	position: relative;
 	font-size: 1rem;
-}
-
-/*
- * Modified from https://www.w3schools.com/howto/howto_css_switch.asp
-*/
-
-/* The switch - the box around the slider */
-.defence-mechanism label.switch {
-	position: absolute;
-	top: 0.75rem;
-	right: 0.75rem;
-	width: 2rem;
-	height: 1rem;
-}
-
-.defence-mechanism label.switch:focus-within {
-	border-radius: 0.5rem;
-	outline-style: auto;
-}
-
-/* Hide default HTML checkbox */
-.defence-mechanism label.switch > input {
-	width: 0;
-	height: 0;
-	opacity: 0;
-}
-
-/* The slider */
-.defence-mechanism label.switch > .slider {
-	--slider-border-width: 0.125rem;
-
-	position: absolute;
-	inset: 0;
-	border: var(--slider-border-width) solid var(--main-toggle-off-border-colour);
-	background-color: var(--main-toggle-off-colour);
-	cursor: pointer;
-	transition: 0.4s;
-}
-
-.defence-mechanism label.switch > .slider::before {
-	content: '';
-	position: absolute;
-	top: calc(-1 * var(--slider-border-width));
-	left: calc(-1 * var(--slider-border-width));
-	width: 1rem;
-	height: 1rem;
-	background-color: var(--main-toggle-ball-colour);
-	transition: 0.4s;
-}
-
-.defence-mechanism label.switch > input:focus + .slider {
-	box-shadow: 0 0 0.0625rem var(--main-toggle-on-colour);
-}
-
-.defence-mechanism label.switch > input:checked + .slider {
-	border-color: var(--main-toggle-on-border-colour);
-	background-color: var(--main-toggle-on-colour);
-}
-
-.defence-mechanism label.switch > input:checked + .slider::before {
-	transform: translateX(1rem);
-}
-
-/* Rounded sliders */
-.defence-mechanism label.switch > .slider.round {
-	border-radius: 0.5rem;
-}
-
-.defence-mechanism label.switch > .slider.round::before {
-	border-radius: 50%;
 }
 
 .defence-mechanism .info-box {
 	font-size: 0.875rem;
 }
 
-.defence-mechanism .info-box :first-child {
+/* .defence-mechanism .info-box :first-child {
 	margin-top: 0;
+} */
+
+/* the expanded description and further controls */
+.defence-mechanism .info-box {
+	font-size: 0.875rem;
+	padding: 0.5em;
 }
 
 .defence-mechanism .info-box .validation-text {
@@ -103,4 +77,107 @@
 
 .defence-mechanism .prompt-enclosure-configuration-area {
 	padding: 0;
+}
+
+/* adapted from: https://adrianroselli.com/2019/03/under-engineered-toggles.html */
+
+/* default checkbox hidden without removing it from the DOM */
+.toggles [type='checkbox'] {
+	position: absolute;
+	top: auto;
+	overflow: hidden;
+	clip: rect(1px, 1px, 1px, 1px);
+	width: 1px;
+	height: 1px;
+	white-space: nowrap;
+}
+
+/* the  label */
+.toggles [type='checkbox'] + label {
+	display: block;
+	position: relative;
+	max-width: fit-content;
+	text-align: right;
+	padding-right: 3em;
+}
+
+/* the  label hovered or focused*/
+.toggles [type='checkbox']:focus + label,
+.toggles [type='checkbox']:hover + label {
+	color: var(--main-text-accent-colour);
+}
+
+.toggles [type='checkbox']:focus + label::before,
+.toggles [type='checkbox']:hover + label::before {
+	box-shadow: 0 0 0.3em var(--main-text-colour);
+}
+
+.toggles [type='checkbox']:focus + label::after,
+.toggles [type='checkbox']:hover + label::after {
+	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50' cy='50' r='50' fill='rgba(0,0,0,.25)'/%3E%3C/svg%3E");
+	background-size: 30%;
+	background-repeat: no-repeat;
+	background-position: center center;
+}
+
+.toggles [type='checkbox'] + label::before,
+.toggles [type='checkbox'] + label::after {
+	content: '';
+	position: absolute;
+	height: 0.9em;
+	transition: all 0.25s ease;
+}
+
+/* background oval before it's checked */
+.toggles [type='checkbox'] + label::before {
+	right: 0;
+	top: 0.1em;
+	width: 1.9em;
+	border: 0.15em solid var(--main-toggle-off-border-colour);
+	background: var(--main-toggle-off-colour);
+	border-radius: 1.1em;
+}
+
+/* round toggle slider */
+.toggles [type='checkbox'] + label::after {
+	right: 0.95em;
+	top: 0.17em;
+	background: var(--main-text-colour);
+	background-position: center center;
+	border-radius: 50%;
+	width: 1em;
+	border: 0.05em solid var(--main-toggle-off-border-colour);
+}
+
+/* round toggle slider sliding to the right */
+.toggles [type='checkbox']:checked + label::after {
+	right: 0.1em;
+	border-color: var(--main-toggle-on-border-colour);
+	color: var(--main-toggle-on-border-colour);
+}
+
+/* background oval when it's checked */
+.toggles [type='checkbox']:checked + label::before {
+	background-color: var(--main-toggle-on-border-colour);
+	border-color: var(--main-toggle-on-border-colour);
+}
+
+/* Windows High Contrast Mode Support */
+@media screen and (-ms-high-contrast: active) {
+	.toggles [type='checkbox']:focus + label::before,
+	.toggles [type='checkbox']:hover + label::before {
+		outline: 1px dotted windowText;
+		outline-offset: 0.25em;
+	}
+	.toggles [type='checkbox'] + label::after {
+		background-color: windowText;
+	}
+}
+
+/* Reduced motion */
+@media screen and (prefers-reduced-motion: reduce) {
+	.toggles [type='checkbox'] + label::before,
+	.toggles [type='checkbox'] + label::after {
+		transition: none;
+	}
 }

--- a/frontend/src/components/DefenceBox/DefenceMechanism.css
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.css
@@ -120,7 +120,8 @@
 
 .toggles [type='checkbox']:focus + label::before,
 .toggles [type='checkbox']:hover + label::before {
-	box-shadow: 0 0 0.3em var(--main-text-colour);
+	outline: 0.25rem solid var(--accent-border-colour);
+	outline-offset: 0.125rem;
 }
 
 .toggles [type='checkbox']:focus + label::after,

--- a/frontend/src/components/DefenceBox/DefenceMechanism.css
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.css
@@ -1,8 +1,8 @@
 .defence-mechanism-fieldset {
+	min-height: fit-content;
+	margin: 0.1em;
 	border: 0.25rem solid var(--control-config-border);
 	border-radius: 0.5rem;
-	margin: 0.1em;
-	min-height: fit-content;
 }
 
 /* the name of the fieldset */
@@ -13,9 +13,9 @@
 /* the more button to expand the details */
 .defence-mechanism-summary {
 	width: fit-content;
+	padding: 0.5rem;
 	border: 0.125rem outset var(--control-config-border);
 	border-radius: 0.25rem;
-	padding: 0.5rem;
 }
 
 /* style for when details element is expanded */
@@ -23,10 +23,11 @@
 	border-style: inset;
 }
 
-/* remove the default triangle on the summary element*/
+/* remove the default triangle on the summary element */
 .defence-mechanism-fieldset details > summary {
 	list-style: none;
 }
+
 .defence-mechanism-fieldset details > summary::-webkit-details-marker {
 	display: none;
 }
@@ -55,8 +56,8 @@
 
 /* the expanded description and further controls */
 .defence-mechanism .info-box {
-	font-size: 0.875rem;
 	padding: 0.5em;
+	font-size: 0.875rem;
 }
 
 .defence-mechanism .info-box .validation-text {
@@ -90,14 +91,14 @@
 
 /* the  label */
 .toggles [type='checkbox'] + label {
-	display: block;
 	position: relative;
+	display: block;
 	max-width: fit-content;
-	text-align: right;
 	padding-right: 3em;
+	text-align: right;
 }
 
-/* the  label hovered or focused*/
+/* the  label hovered or focused */
 .toggles [type='checkbox']:focus + label,
 .toggles [type='checkbox']:hover + label {
 	color: var(--main-text-accent-colour);
@@ -111,9 +112,9 @@
 .toggles [type='checkbox']:focus + label::after,
 .toggles [type='checkbox']:hover + label::after {
 	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50' cy='50' r='50' fill='rgba(0,0,0,.25)'/%3E%3C/svg%3E");
+	background-position: center center;
 	background-size: 30%;
 	background-repeat: no-repeat;
-	background-position: center center;
 }
 
 .toggles [type='checkbox'] + label::before,
@@ -126,23 +127,23 @@
 
 /* background oval before it's checked */
 .toggles [type='checkbox'] + label::before {
-	right: 0;
 	top: 0.1em;
+	right: 0;
 	width: 1.9em;
 	border: 0.15em solid var(--main-toggle-off-border-colour);
-	background: var(--main-toggle-off-colour);
 	border-radius: 1.1em;
+	background: var(--main-toggle-off-colour);
 }
 
 /* round toggle slider */
 .toggles [type='checkbox'] + label::after {
-	right: 0.95em;
 	top: 0.17em;
-	background: var(--main-text-colour);
-	background-position: center center;
-	border-radius: 50%;
+	right: 0.95em;
 	width: 1em;
 	border: 0.05em solid var(--main-toggle-off-border-colour);
+	border-radius: 50%;
+	background: var(--main-text-colour);
+	background-position: center center;
 }
 
 /* round toggle slider sliding to the right */
@@ -154,8 +155,8 @@
 
 /* background oval when it's checked */
 .toggles [type='checkbox']:checked + label::before {
-	background-color: var(--main-toggle-on-border-colour);
 	border-color: var(--main-toggle-on-border-colour);
+	background-color: var(--main-toggle-on-border-colour);
 }
 
 /* Reduced motion */

--- a/frontend/src/components/DefenceBox/DefenceMechanism.css
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.css
@@ -1,16 +1,14 @@
 .defence-mechanism-fieldset {
 	min-height: fit-content;
-	margin: 0.1em;
+	margin: 0;
 	border: 0.25rem solid var(--control-config-border);
 	border-radius: 0.5rem;
 }
 
-/* the name of the fieldset */
 .defence-mechanism-legend {
 	padding: 0.3em;
 }
 
-/* the more button to expand the details */
 .defence-mechanism-summary {
 	width: fit-content;
 	padding: 0.5rem;
@@ -22,7 +20,6 @@
 	font-size: 1rem;
 }
 
-/* remove the default triangle on the summary element */
 .defence-mechanism-fieldset details > summary {
 	list-style: none;
 }
@@ -31,12 +28,10 @@
 	display: none;
 }
 
-/* style for when details element is expanded */
 .defence-mechanism-fieldset details[open] > summary {
 	border-style: inset;
 }
 
-/* the toggle and label combined */
 .defence-mechanism-form {
 	position: absolute;
 	right: 1em;
@@ -50,7 +45,6 @@
 	margin-top: 0;
 }
 
-/* the expanded description and further controls */
 .defence-mechanism .info-box {
 	padding: 0.5em;
 	font-size: 0.875rem;
@@ -74,7 +68,6 @@
 
 /* adapted from: https://adrianroselli.com/2019/03/under-engineered-toggles.html */
 
-/* default checkbox hidden without removing it from the DOM */
 .toggles [type='checkbox'] {
 	position: absolute;
 	top: auto;
@@ -85,7 +78,6 @@
 	white-space: nowrap;
 }
 
-/* the  label */
 .toggles [type='checkbox'] + label {
 	position: relative;
 	display: block;
@@ -102,13 +94,11 @@
 	transition: all 0.25s ease;
 }
 
-/* the  label hovered or focused */
 .toggles [type='checkbox']:focus + label,
 .toggles [type='checkbox']:hover + label {
 	color: var(--main-text-accent-colour);
 }
 
-/* background oval before it's checked */
 .toggles [type='checkbox'] + label::before {
 	top: 0.1em;
 	right: 0;
@@ -118,7 +108,6 @@
 	background: var(--main-toggle-off-colour);
 }
 
-/* round toggle slider */
 .toggles [type='checkbox'] + label::after {
 	top: 0.17em;
 	right: 0.95em;
@@ -142,20 +131,17 @@
 	background-repeat: no-repeat;
 }
 
-/* round toggle slider sliding to the right */
 .toggles [type='checkbox']:checked + label::after {
 	right: 0.1em;
 	border-color: var(--main-toggle-on-border-colour);
 	color: var(--main-toggle-on-border-colour);
 }
 
-/* background oval when it's checked */
 .toggles [type='checkbox']:checked + label::before {
 	border-color: var(--main-toggle-on-border-colour);
 	background-color: var(--main-toggle-on-border-colour);
 }
 
-/* Reduced motion */
 @media screen and (prefers-reduced-motion: reduce) {
 	.toggles [type='checkbox'] + label::before,
 	.toggles [type='checkbox'] + label::after {

--- a/frontend/src/components/DefenceBox/DefenceMechanism.tsx
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.tsx
@@ -99,7 +99,7 @@ function DefenceMechanism({
 					setConfigKey(configKey + 1);
 				}}
 			>
-				<summary className="defence-mechanism-summary">details</summary>
+				<summary className="defence-mechanism-summary">Details</summary>
 				<div className="info-box">
 					<p>{defenceDetail.info}</p>
 

--- a/frontend/src/components/DefenceBox/DefenceMechanism.tsx
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.tsx
@@ -69,21 +69,14 @@ function DefenceMechanism({
 		}
 	}
 	return (
-		<details
-			className="defence-mechanism"
-			onToggle={() => {
-				// re-render the configuration component when detail is toggled
-				// this is to resize the textarea when detail is expanded
-				setConfigKey(configKey + 1);
-			}}
-		>
-			<summary>
-				<span aria-hidden={defenceDetail.id !== DEFENCE_ID.PROMPT_ENCLOSURE}>
-					{defenceDetail.name}
-				</span>
-				{defenceDetail.id !== DEFENCE_ID.PROMPT_ENCLOSURE && (
-					<label className="switch">
+		<fieldset className="defence-mechanism-fieldset">
+			<legend className="defence-mechanism-legend">{defenceDetail.name}</legend>
+			{defenceDetail.id !== DEFENCE_ID.PROMPT_ENCLOSURE && (
+				<form className="defence-mechanism-form">
+					<div className="toggles">
 						<input
+							id={defenceDetail.id}
+							className="toggle-switch-input"
 							type="checkbox"
 							placeholder="defence-toggle"
 							onChange={() => {
@@ -91,51 +84,62 @@ function DefenceMechanism({
 							}}
 							// set checked if defence is active
 							checked={defenceDetail.isActive}
-							aria-label={defenceDetail.name}
 						/>
-						<span className="slider round"></span>
-					</label>
-				)}
-			</summary>
-			<div className="info-box">
-				<p>{defenceDetail.info}</p>
+						<label htmlFor={defenceDetail.id}>
+							{defenceDetail.isActive ? 'on' : 'off'}
+						</label>
+					</div>
+				</form>
+			)}
+			<details
+				className="defence-mechanism"
+				onToggle={() => {
+					// re-render the configuration component when detail is toggled
+					// this is to resize the textarea when detail is expanded
+					setConfigKey(configKey + 1);
+				}}
+			>
+				<summary className="defence-mechanism-summary">details</summary>
+				<div className="info-box">
+					<p>{defenceDetail.info}</p>
 
-				{defenceDetail.id !== DEFENCE_ID.PROMPT_ENCLOSURE ? (
-					showConfigurations &&
-					defenceDetail.config.map((config) => {
-						return (
-							<DefenceConfiguration
-								defence={defenceDetail}
-								key={config.id + configKey}
-								isActive={defenceDetail.isActive}
-								config={config}
-								setConfigurationValue={setConfigurationValue}
-								resetConfigurationValue={resetConfigurationValue}
-							/>
-						);
-					})
-				) : (
-					<PromptEnclosureDefenceMechanism
-						defences={promptEnclosureDefences}
-						toggleDefence={toggleDefence}
-						showConfigurations={showConfigurations}
-						setConfigurationValue={setConfigurationValue}
-						resetConfigurationValue={resetConfigurationValue}
-					/>
-				)}
-
-				{showConfiguredText &&
-					(configValidated ? (
-						<p className="validation-text">
-							<TiTick /> defence successfully configured
-						</p>
+					{defenceDetail.id !== DEFENCE_ID.PROMPT_ENCLOSURE ? (
+						showConfigurations &&
+						defenceDetail.config.map((config) => {
+							return (
+								<DefenceConfiguration
+									defence={defenceDetail}
+									key={config.id + configKey}
+									isActive={defenceDetail.isActive}
+									config={config}
+									setConfigurationValue={setConfigurationValue}
+									resetConfigurationValue={resetConfigurationValue}
+								/>
+							);
+						})
 					) : (
-						<p className="validation-text">
-							<TiTimes /> invalid input - configuration failed
-						</p>
-					))}
-			</div>
-		</details>
+						<PromptEnclosureDefenceMechanism
+							defences={promptEnclosureDefences}
+							toggleDefence={toggleDefence}
+							showConfigurations={showConfigurations}
+							setConfigurationValue={setConfigurationValue}
+							resetConfigurationValue={resetConfigurationValue}
+						/>
+					)}
+
+					{showConfiguredText &&
+						(configValidated ? (
+							<p className="validation-text">
+								<TiTick /> defence successfully configured
+							</p>
+						) : (
+							<p className="validation-text">
+								<TiTimes /> invalid input - configuration failed
+							</p>
+						))}
+				</div>
+			</details>
+		</fieldset>
 	);
 }
 

--- a/frontend/src/components/MainComponent/MainBody.css
+++ b/frontend/src/components/MainComponent/MainBody.css
@@ -22,6 +22,6 @@
 .right-side-bar {
 	display: flex;
 	flex-direction: column-reverse;
-	height: 100%;
 	width: 30%;
+	height: 100%;
 }

--- a/frontend/src/components/MainComponent/MainBody.css
+++ b/frontend/src/components/MainComponent/MainBody.css
@@ -22,6 +22,6 @@
 .right-side-bar {
 	display: flex;
 	flex-direction: column-reverse;
-	width: 30%;
 	height: 100%;
+	width: 30%;
 }

--- a/frontend/src/components/ThemedInput/ThemedNumberInput.tsx
+++ b/frontend/src/components/ThemedInput/ThemedNumberInput.tsx
@@ -43,7 +43,7 @@ function ThemedNumberInput({
 			className={inputClass}
 			type="number"
 			value={content}
-			disabled={disabled}
+			readOnly={disabled}
 			onBlur={onBlur}
 			onChange={inputChanged}
 			onKeyUp={inputKeyUp}


### PR DESCRIPTION
## Description
Redesigned the toggle buttons and Configurations on the left side to ensure Screen Reader support (NVDA for Firefox & Chrome, Narrator for Edge).

## Screenshots
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/296f402b-7595-4218-a0e6-be01f010ab46)

## Notes
- Defence configurations grouped into fieldsets, which allows for multiple input controls to be clearly linked for Assistive Technology. 
- Toggle buttons reworked giving them a visual label (on/off)
- Summary button (the button that expands to see more info) reworked to look like a button

## Concerns 
(would prefer to address in separate tickets to keep this PR small, but noticed as part of this)
- The Model Temperature configurations could also be changed to use this new design for consistently
- The tabbing order is slightly controversial: The on/off button comes before the details button, it might be expected to be the other way round since we read left to right, although you could also argue that the on/off is the main control (and slightly higher up than the details button) and that the details button secondary. I tried to switch them around, but this creates issues for the layout when the details section is expanded. Could make this order more clear with nudging the on/off toggle a bit further up. Personally I think it's not perfect, but good enough. Please test this out by tabbing through the controls and let me know what you think.
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/24c770d4-7f24-41bc-b34d-d47560a48f8d)
- <s>The text/number inputs of the defences are not available to screen reader when the defence is inactive. </s> really easy fix, so not a concern anymore

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing