### PR TITLE
757 various visual bugs

### DIFF
--- a/frontend/src/components/ChatBox/ChatBoxFeed.css
+++ b/frontend/src/components/ChatBox/ChatBoxFeed.css
@@ -2,7 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 0.75rem;
-	justify-content: center;
+	justify-content: stretch;
 	overflow-y: auto;
 	height: fit-content;
 	padding: 0.5rem 2rem;

--- a/frontend/src/components/HandbookOverlay/HandbookOverlay.css
+++ b/frontend/src/components/HandbookOverlay/HandbookOverlay.css
@@ -27,6 +27,7 @@
 	margin-right: 0.5rem;
 	margin-bottom: 0.25rem;
 	padding: 0 1.75rem 0.5rem;
+	overflow-y: auto;
 
 	/* firefox scrollbar styling */
 	scrollbar-color: var(--handbook-scrollbar-colour) transparent;

--- a/frontend/src/components/Overlay/Overlay.css
+++ b/frontend/src/components/Overlay/Overlay.css
@@ -33,6 +33,7 @@
 	border: 0.1875rem solid transparent;
 	color: inherit;
 	font-weight: bold;
+	font-size: 1.5rem;
 }
 
 .overlay > .close-button:focus-visible {

--- a/frontend/src/components/ThemedButtons/ThemedButton.css
+++ b/frontend/src/components/ThemedButtons/ThemedButton.css
@@ -22,6 +22,7 @@
 
 .themed-button.disabled {
 	background-color: var(--action-button-disabled-background-colour);
+	border-color: var(--action-button-disabled-background-colour);
 	color: var(--action-button-disabled-text-colour);
 }
 


### PR DESCRIPTION
## Description

- fixes handbook scroll behaviour
- close button on modals back to normal size
- blue border removed from disabled back button [themedButton] in doc viewer
- fixes chat feed scroll issue (couldn't scroll up all the way to the top of the feed)

## Screenshots

### handbook scroll behaviour

no scroll
![image](https://github.com/ScottLogic/prompt-injection/assets/118171430/3989cf01-2ccd-4998-a4d3-ba8b8bab4809)

scrolled to bottom
![image](https://github.com/ScottLogic/prompt-injection/assets/118171430/0d874bf2-cb54-421a-ab0d-fc461705ae4d)

### close button
![image](https://github.com/ScottLogic/prompt-injection/assets/118171430/5d4ab877-8c46-43a9-9a66-8981cd1c8ba4)

### blue border on disabled back button in docViewer
![image](https://github.com/ScottLogic/prompt-injection/assets/118171430/1ff11faa-1c7d-4c38-976d-284246eb75e0)

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
