### PR TITLE
Fix reset progress bug in remote

### DIFF
--- a/frontend/src/service/documentService.ts
+++ b/frontend/src/service/documentService.ts
@@ -2,14 +2,15 @@ import { DocumentMeta } from '@src/models/document';
 
 import { getBackendUrl, sendRequest } from './backendService';
 
+const PATH = 'documents';
+
 async function getDocumentMetas(signal?: AbortSignal): Promise<DocumentMeta[]> {
-	const path = 'documents';
-	const response = await sendRequest(path, { method: 'GET', signal });
+	const response = await sendRequest(PATH, { method: 'GET', signal });
 	let documentMetas = (await response.json()) as DocumentMeta[];
 	documentMetas = documentMetas.map((documentMeta) => {
 		return {
 			...documentMeta,
-			uri: `${getBackendUrl()}${path}/${documentMeta.folder}/${
+			uri: `${getBackendUrl()}${PATH}/${documentMeta.folder}/${
 				documentMeta.filename
 			}`,
 		};

--- a/frontend/src/service/levelService.ts
+++ b/frontend/src/service/levelService.ts
@@ -1,7 +1,9 @@
 import { sendRequest } from './backendService';
 
+const PATH = 'reset';
+
 async function resetAllLevelProgress(): Promise<boolean> {
-	const response = await sendRequest(`/reset`, {
+	const response = await sendRequest(PATH, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',


### PR DESCRIPTION
## Description

The relevant change is removing the leading slash from the request path in levelService. The other change is just for consistency, to match the other services.

Resolves #787 

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
