### PR TITLE
Prevent mutating state reset template

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { importMetaUrl } from './importMetaUtils';
 import { ChatModel, defaultChatModel } from './models/chat';
-import { LevelState, levelsInitialState } from './models/level';
+import { LevelState, getInitialLevelStates } from './models/level';
 import { router } from './router';
 
 dotenv.config();
@@ -55,7 +55,7 @@ app.use((req, _res, next) => {
 	// initialise session variables first time
 	if (!req.session.initialised) {
 		req.session.chatModel = defaultChatModel;
-		req.session.levelState = levelsInitialState;
+		req.session.levelState = getInitialLevelStates();
 		req.session.initialised = true;
 	}
 	next();

--- a/backend/src/controller/resetController.ts
+++ b/backend/src/controller/resetController.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from 'express';
 
-import { levelsInitialState } from '@src/models/level';
+import { getInitialLevelStates } from '@src/models/level';
 
 function handleResetProgress(req: Request, res: Response) {
 	console.debug('Resetting progress for all levels', req.session.levelState);
-	req.session.levelState = levelsInitialState;
+	req.session.levelState = getInitialLevelStates();
 	res.send(req.session.levelState);
 }
 

--- a/backend/src/models/level.ts
+++ b/backend/src/models/level.ts
@@ -21,12 +21,15 @@ interface LevelState {
 function getInitialLevelStates() {
 	return Object.values(LEVEL_NAMES)
 		.filter((value) => Number.isNaN(Number(value)))
-		.map((value) => ({
-			level: value as LEVEL_NAMES,
-			chatHistory: [],
-			defences: defaultDefences,
-			sentEmails: [],
-		} as LevelState));
+		.map(
+			(value) =>
+				({
+					level: value as LEVEL_NAMES,
+					chatHistory: [],
+					defences: defaultDefences,
+					sentEmails: [],
+				} as LevelState)
+		);
 }
 
 export { LEVEL_NAMES, getInitialLevelStates };

--- a/backend/src/models/level.ts
+++ b/backend/src/models/level.ts
@@ -18,14 +18,16 @@ interface LevelState {
 	sentEmails: EmailInfo[];
 }
 
-const levelsInitialState = Object.values(LEVEL_NAMES)
-	.filter((value) => Number.isNaN(Number(value)))
-	.map((value) => ({
-		level: value as LEVEL_NAMES,
-		chatHistory: [],
-		defences: defaultDefences,
-		sentEmails: [],
-	}));
+function getInitialLevelStates() {
+	return Object.values(LEVEL_NAMES)
+		.filter((value) => Number.isNaN(Number(value)))
+		.map((value) => ({
+			level: value as LEVEL_NAMES,
+			chatHistory: [],
+			defences: defaultDefences,
+			sentEmails: [],
+		} as LevelState));
+}
 
-export { LEVEL_NAMES, levelsInitialState };
+export { LEVEL_NAMES, getInitialLevelStates };
 export type { LevelState };

--- a/backend/test/unit/controller/resetController.test.ts
+++ b/backend/test/unit/controller/resetController.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@src/models/chat';
 import { DEFENCE_ID, Defence, DefenceConfigItem } from '@src/models/defence';
 import { EmailInfo } from '@src/models/email';
-import { LEVEL_NAMES, LevelState, levelsInitialState } from '@src/models/level';
+import { LEVEL_NAMES, LevelState, getInitialLevelStates } from '@src/models/level';
 
 declare module 'express-session' {
 	interface Session {
@@ -69,7 +69,7 @@ describe('handleResetProgress unit tests', () => {
 
 		const res = responseMock();
 		handleResetProgress(reqWithChatHistory, res);
-		expect(res.send).toHaveBeenCalledWith(levelsInitialState);
+		expect(res.send).toHaveBeenCalledWith(getInitialLevelStates());
 	});
 
 	test('GIVEN sent emails THEN should reset emails for all levels', () => {
@@ -84,7 +84,7 @@ describe('handleResetProgress unit tests', () => {
 
 		const res = responseMock();
 		handleResetProgress(reqWithSentEmails, res);
-		expect(res.send).toHaveBeenCalledWith(levelsInitialState);
+		expect(res.send).toHaveBeenCalledWith(getInitialLevelStates());
 	});
 
 	test('GIVEN defences THEN should reset defences for levels', () => {
@@ -116,6 +116,6 @@ describe('handleResetProgress unit tests', () => {
 
 		const res = responseMock();
 		handleResetProgress(reqWithDefences, res);
-		expect(res.send).toHaveBeenCalledWith(levelsInitialState);
+		expect(res.send).toHaveBeenCalledWith(getInitialLevelStates());
 	});
 });

--- a/backend/test/unit/controller/resetController.test.ts
+++ b/backend/test/unit/controller/resetController.test.ts
@@ -10,7 +10,11 @@ import {
 } from '@src/models/chat';
 import { DEFENCE_ID, Defence, DefenceConfigItem } from '@src/models/defence';
 import { EmailInfo } from '@src/models/email';
-import { LEVEL_NAMES, LevelState, getInitialLevelStates } from '@src/models/level';
+import {
+	LEVEL_NAMES,
+	LevelState,
+	getInitialLevelStates,
+} from '@src/models/level';
 
 declare module 'express-session' {
 	interface Session {


### PR DESCRIPTION
## Description

There was a problem that we only saw in remote deployment, in which the state object we were using in resetting the game progress could be mutated, resulting in chat persisting even after a reset. The first reset worked ok, but all subsequent ones would be corrupted, due to the way module loading works.

I have corrected the "fresh state template" object to be a function that always returns a new copy.

Resolves #787 

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [x] Added or updated tests
- [x] Ensured the workflow steps are passing
