### PR TITLE
fix to the scrollbar showing up on chrome/edge

### DIFF
--- a/frontend/src/components/ControlPanel/ControlPanel.css
+++ b/frontend/src/components/ControlPanel/ControlPanel.css
@@ -8,7 +8,7 @@
 
 .control-panel::-webkit-scrollbar {
 	display: none;
-	width: 0px;
+	width: 0;
 	background: transparent;
 }
 

--- a/frontend/src/components/ControlPanel/ControlPanel.css
+++ b/frontend/src/components/ControlPanel/ControlPanel.css
@@ -6,8 +6,10 @@
 	scrollbar-width: none;
 }
 
-.control::-webkit-scrollbar {
+.control-panel::-webkit-scrollbar {
 	display: none;
+	width: 0px;
+	background: transparent;
 }
 
 .control-panel .control-collapsible-section {


### PR DESCRIPTION
## Description

fixed the css so that the scrollbar doesn't show up on chrome/edge for the left side control panel

## Screenshots
![image](https://github.com/ScottLogic/prompt-injection/assets/125262433/03306dbb-6025-4f8b-acbc-d7ec532981ab)



- [ x] Linked the relevant Issue
- https://github.com/ScottLogic/prompt-injection/issues/723
- [x ] Added tests
- [ x] Ensured the workflow steps are passing
