### PR TITLE
Make short mission info non-clickable and add button #535

### DIFF
--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
@@ -3,7 +3,6 @@
 	gap: 0.5rem;
 	align-items: center;
 	padding: 0.5rem 1.5rem;
-	border: 0.5rem solid transparent;
 	background-color: var(--level-banner-background-colour);
 	color: var(--level-banner-text-colour);
 	text-align: left;

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
@@ -26,6 +26,20 @@
 	font-size: 1rem;
 }
 
-.level-mission-info-banner:hover {
-	background-color: var(--level-banner-background-colour-hover);
+.level-mission-info-banner .themed-button {
+	height: auto;
+	white-space: nowrap;
+}
+
+.info-icon {
+	margin-right: 0.25rem;
+	padding: 0 0.4rem;
+	border: 0.2rem;
+	border-style: solid;
+	border-color: var(--action-button-text-colour);
+	border-radius: 50%;
+	background-color: var(--action-button-text-colour);
+	color: var(--action-button-background-colour);
+	font: 1rem serif;
+	font-weight: bold;
 }

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
@@ -16,6 +16,7 @@
 
 .level-title-area {
 	min-width: 10%;
+	margin: 1rem 0;
 	font-weight: 800;
 	font-size: 1.875rem;
 }
@@ -26,14 +27,18 @@
 }
 
 .level-mission-info-banner .themed-button {
+	gap: 0.25rem;
 	height: auto;
+	padding: 0.75rem 1rem;
 	white-space: nowrap;
 }
 
 .info-icon {
-	margin-right: 0.25rem;
-	padding: 0 0.4rem;
-	border: 0.2rem;
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
+	height: auto;
+	padding: 0 0.625rem;
 	border-style: solid;
 	border-color: var(--action-button-text-colour);
 	border-radius: 50%;
@@ -41,4 +46,5 @@
 	color: var(--action-button-background-colour);
 	font: 1rem serif;
 	font-weight: bold;
+	aspect-ratio: 1;
 }

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
@@ -15,7 +15,6 @@
 }
 
 .level-title-area {
-	min-width: 10%;
 	margin: 1rem 0;
 	font-weight: 800;
 	font-size: 1.875rem;

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.css
@@ -1,6 +1,6 @@
 .level-mission-info-banner {
 	display: flex;
-	gap: 0.5rem;
+	gap: 1.5rem;
 	align-items: center;
 	padding: 0.5rem 1.5rem;
 	background-color: var(--level-banner-background-colour);
@@ -19,6 +19,7 @@
 	margin: 1rem 0;
 	font-weight: 800;
 	font-size: 1.875rem;
+	white-space: nowrap;
 }
 
 .level-mission-info-banner > p {
@@ -27,7 +28,7 @@
 }
 
 .level-mission-info-banner .themed-button {
-	gap: 0.25rem;
+	gap: 0.5rem;
 	height: auto;
 	padding: 0.75rem 1rem;
 	white-space: nowrap;
@@ -39,8 +40,6 @@
 	box-sizing: border-box;
 	height: auto;
 	padding: 0 0.625rem;
-	border-style: solid;
-	border-color: var(--action-button-text-colour);
 	border-radius: 50%;
 	background-color: var(--action-button-text-colour);
 	color: var(--action-button-background-colour);

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -1,4 +1,9 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import {
+	render,
+	screen,
+	fireEvent,
+	getDefaultNormalizer,
+} from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { LEVELS } from '@src/Levels';
@@ -21,7 +26,10 @@ describe('LevelMissionInfoBanner component tests', () => {
 		if (!expectedContent)
 			throw new Error(`No missionInfoShort found for level ${currentLevel}`);
 
-		const expectedText = expectedContent.replace(/(<([^>]+)>)/gi, ''); //remove markup!
+		const expectedText = expectedContent
+			.slice(0, expectedContent.indexOf(' <u>'))
+			.replace(/\s+/g, ' '); //normalising whitespace
+
 		const banner = screen.getByText(expectedText);
 		expect(banner).toContainHTML(expectedContent);
 	});

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -1,4 +1,9 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import {
+	render,
+	screen,
+	fireEvent,
+	getDefaultNormalizer,
+} from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { LEVELS } from '@src/Levels';
@@ -21,10 +26,10 @@ describe('LevelMissionInfoBanner component tests', () => {
 		if (!expectedContent)
 			throw new Error(`No missionInfoShort found for level ${currentLevel}`);
 
-		const expectedText = expectedContent
-			.slice(0, expectedContent.indexOf(' <u>'))
-			.replace(/\s+/g, ' '); //normalising whitespace
-
+		const expectedText = getDefaultNormalizer()(
+			expectedContent.slice(0, expectedContent.indexOf(' <u>'))
+		);
+		console.log(expectedText);
 		const banner = screen.getByText(expectedText);
 		expect(banner).toContainHTML(expectedContent);
 	});

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -1,9 +1,4 @@
-import {
-	render,
-	screen,
-	fireEvent,
-	getDefaultNormalizer,
-} from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { LEVELS } from '@src/Levels';

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -29,7 +29,6 @@ describe('LevelMissionInfoBanner component tests', () => {
 		const expectedText = getDefaultNormalizer()(
 			expectedContent.slice(0, expectedContent.indexOf(' <u>'))
 		);
-		console.log(expectedText);
 		const banner = screen.getByText(expectedText);
 		expect(banner).toContainHTML(expectedContent);
 	});

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -16,9 +16,9 @@ describe('LevelMissionInfoBanner component tests', () => {
 			/>
 		);
 
-		const button = screen.getByRole('button');
+		const banner = screen.getByTestId('banner-info');
 		const expectedContent = LEVELS[currentLevel].missionInfoShort ?? '';
-		expect(button).toContainHTML(expectedContent);
+		expect(banner).toContainHTML(expectedContent);
 	});
 
 	test('fires the openOverlay callback on button click', () => {

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -16,8 +16,13 @@ describe('LevelMissionInfoBanner component tests', () => {
 			/>
 		);
 
-		const banner = screen.getByTestId('banner-info');
-		const expectedContent = LEVELS[currentLevel].missionInfoShort ?? '';
+		const expectedContent = LEVELS[currentLevel].missionInfoShort;
+
+		if (!expectedContent)
+			throw new Error(`No missionInfoShort found for level ${currentLevel}`);
+
+		const expectedText = expectedContent.replace(/(<([^>]+)>)/gi, ''); //remove markup!
+		const banner = screen.getByText(expectedText);
 		expect(banner).toContainHTML(expectedContent);
 	});
 

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
@@ -1,9 +1,8 @@
 import { LEVELS } from '@src/Levels';
+import ThemedButton from '@src/components/ThemedButtons/ThemedButton';
 import { LEVEL_NAMES } from '@src/models/level';
 
 import './LevelMissionInfoBanner.css';
-
-import ThemedButton from '../ThemedButtons/ThemedButton';
 
 function LevelMissionInfoBanner({
 	currentLevel,

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
@@ -3,6 +3,8 @@ import { LEVEL_NAMES } from '@src/models/level';
 
 import './LevelMissionInfoBanner.css';
 
+import ThemedButton from '../ThemedButtons/ThemedButton';
+
 function LevelMissionInfoBanner({
 	currentLevel,
 	openOverlay,
@@ -11,14 +13,20 @@ function LevelMissionInfoBanner({
 	openOverlay: () => void;
 }) {
 	return (
-		<button className="level-mission-info-banner" onClick={openOverlay}>
-			<span className="level-title-area">{`Level ${currentLevel + 1}`}</span>
+		<span className="level-mission-info-banner">
+			<h2 className="level-title-area">{`Level ${currentLevel + 1}`}</h2>
 			<p
 				dangerouslySetInnerHTML={{
 					__html: LEVELS[currentLevel].missionInfoShort ?? '',
 				}}
 			></p>
-		</button>
+			<ThemedButton onClick={openOverlay}>
+				<p className="info-icon" aria-hidden="true">
+					i
+				</p>
+				Mission Info
+			</ThemedButton>
+		</span>
 	);
 }
 export default LevelMissionInfoBanner;

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
@@ -15,6 +15,7 @@ function LevelMissionInfoBanner({
 		<span className="level-mission-info-banner">
 			<h2 className="level-title-area">{`Level ${currentLevel + 1}`}</h2>
 			<p
+				data-testid="banner-info"
 				dangerouslySetInnerHTML={{
 					__html: LEVELS[currentLevel].missionInfoShort ?? '',
 				}}

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
@@ -21,9 +21,9 @@ function LevelMissionInfoBanner({
 				}}
 			></p>
 			<ThemedButton onClick={openOverlay}>
-				<p className="info-icon" aria-hidden="true">
+				<span className="info-icon" aria-hidden="true">
 					i
-				</p>
+				</span>
 				Mission Info
 			</ThemedButton>
 		</span>

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
@@ -15,7 +15,6 @@ function LevelMissionInfoBanner({
 		<span className="level-mission-info-banner">
 			<h2 className="level-title-area">{`Level ${currentLevel + 1}`}</h2>
 			<p
-				data-testid="banner-info"
 				dangerouslySetInnerHTML={{
 					__html: LEVELS[currentLevel].missionInfoShort ?? '',
 				}}


### PR DESCRIPTION
## Description

changed level banner format to include actual button with mission info as per ticket #535 

## Screenshots

<img width="959" alt="image" src="https://github.com/ScottLogic/prompt-injection/assets/125262433/720e873a-3287-4826-bd18-3840e4f2ae0a">


## Notes

- Bullet point list with
- any notable code changes
- or explanations regarding this PR

|## link:
https://github.com/orgs/ScottLogic/projects/37/views/2?pane=issue&itemId=44015553

Resolves #535 