### PR TITLE
convert the level enum

### DIFF
--- a/backend/src/document.ts
+++ b/backend/src/document.ts
@@ -93,9 +93,7 @@ async function initDocumentVectors() {
 	const docVectors: DocumentsVector[] = [];
 	const commonDocuments = await getDocuments(getFilepath('common'));
 
-	const levelValues = Object.values(LEVEL_NAMES)
-		.filter((value) => !isNaN(Number(value)))
-		.map((value) => Number(value));
+	const levelValues = Object.values(LEVEL_NAMES);
 
 	for (const level of levelValues) {
 		const commonAndLevelDocuments = commonDocuments.concat(

--- a/backend/src/models/level.ts
+++ b/backend/src/models/level.ts
@@ -4,12 +4,14 @@ import { ChatMessage } from './chatMessage';
 import { Defence } from './defence';
 import { EmailInfo } from './email';
 
-enum LEVEL_NAMES {
-	LEVEL_1,
-	LEVEL_2,
-	LEVEL_3,
-	SANDBOX,
-}
+const LEVEL_NAMES = {
+	LEVEL_1: 0,
+	LEVEL_2: 1,
+	LEVEL_3: 2,
+	SANDBOX: 3,
+} as const;
+
+type LEVEL_NAMES = (typeof LEVEL_NAMES)[keyof typeof LEVEL_NAMES];
 
 interface LevelState {
 	level: LEVEL_NAMES;
@@ -19,18 +21,16 @@ interface LevelState {
 }
 
 function getInitialLevelStates() {
-	return Object.values(LEVEL_NAMES)
-		.filter((value) => Number.isNaN(Number(value)))
-		.map(
-			(value) =>
-				({
-					level: value as LEVEL_NAMES,
-					chatHistory: [],
-					defences: defaultDefences,
-					sentEmails: [],
-				} as LevelState)
-		);
+	return Object.values(LEVEL_NAMES).map(
+		(level) =>
+			({
+				level,
+				chatHistory: [],
+				defences: defaultDefences,
+				sentEmails: [],
+			} as LevelState)
+	);
 }
 
-export { LEVEL_NAMES, getInitialLevelStates };
+export { getInitialLevelStates, LEVEL_NAMES };
 export type { LevelState };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,14 @@ function App() {
 		const currentLevelStr = localStorage.getItem('currentLevel');
 		if (currentLevelStr && !isNewUser) {
 			// start the user from where they last left off
-			return parseInt(currentLevelStr);
+			const level = parseInt(currentLevelStr);
+			if (level < LEVEL_NAMES.LEVEL_1 || level > LEVEL_NAMES.SANDBOX) {
+				console.error(
+					`Invalid level ${level} in local storage, defaulting to level 1`
+				);
+				return LEVEL_NAMES.LEVEL_1;
+			}
+			return parseInt(currentLevelStr) as LEVEL_NAMES;
 		} else {
 			// by default, start on level 1
 			return LEVEL_NAMES.LEVEL_1;

--- a/frontend/src/components/HandbookOverlay/Pages/HandbookSystemRole.tsx
+++ b/frontend/src/components/HandbookOverlay/Pages/HandbookSystemRole.tsx
@@ -1,4 +1,4 @@
-import { LEVEL_NAMES, LevelSystemRole } from '@src/models/level';
+import { LevelSystemRole } from '@src/models/level';
 
 import './HandbookPage.css';
 
@@ -6,7 +6,7 @@ function HandbookSystemRole({
 	numCompletedLevels,
 	systemRoles,
 }: {
-	numCompletedLevels: LEVEL_NAMES;
+	numCompletedLevels: number;
 	systemRoles: LevelSystemRole[];
 }) {
 	return (

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -37,7 +37,7 @@ function MainComponent({
 	currentLevel: LEVEL_NAMES;
 	numCompletedLevels: number;
 	closeOverlay: () => void;
-	updateNumCompletedLevels: (level: LEVEL_NAMES) => void;
+	updateNumCompletedLevels: (level: number) => void;
 	openDocumentViewer: () => void;
 	openInformationOverlay: () => void;
 	openLevelsCompleteOverlay: () => void;

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -37,7 +37,7 @@ function MainComponent({
 	currentLevel: LEVEL_NAMES;
 	numCompletedLevels: number;
 	closeOverlay: () => void;
-	updateNumCompletedLevels: (level: number) => void;
+	updateNumCompletedLevels: (level: LEVEL_NAMES) => void;
 	openDocumentViewer: () => void;
 	openInformationOverlay: () => void;
 	openLevelsCompleteOverlay: () => void;

--- a/frontend/src/models/level.ts
+++ b/frontend/src/models/level.ts
@@ -1,9 +1,11 @@
-enum LEVEL_NAMES {
-	LEVEL_1 = 0,
-	LEVEL_2,
-	LEVEL_3,
-	SANDBOX,
-}
+const LEVEL_NAMES = {
+	LEVEL_1: 0,
+	LEVEL_2: 1,
+	LEVEL_3: 2,
+	SANDBOX: 3,
+} as const;
+
+type LEVEL_NAMES = (typeof LEVEL_NAMES)[keyof typeof LEVEL_NAMES];
 
 interface Level {
 	id: LEVEL_NAMES;


### PR DESCRIPTION
## Description

The level being an enum was disrupting with my network calls ticket #824 

## Notes

- Tried switching the values so that sandbox had value 0, level 1 had value 1, level 2 had value 2, etc. This caused lots of problems because many things depend on what order things are declared in arrays, which is not great. But not worth the effort to fix right now

## Checklist

Have you done the following?

- [ ] Linked the relevant Issue | no real ticket for this
- [ ] Added tests | no functional change
- [x] Ensured the workflow steps are passing
