### PR TITLE
686 add skip to topbottom links to chat

### DIFF
--- a/frontend/src/components/ChatBox/ChatBox.css
+++ b/frontend/src/components/ChatBox/ChatBox.css
@@ -68,10 +68,9 @@
 	outline-offset: 0.1rem;
 }
 
-.skip-link {
+.chat-box .skip-link {
 	position: absolute;
 	left: 0;
-	clip: auto;
 	width: 100%;
 	height: auto;
 	padding: 0.5rem 0;
@@ -81,23 +80,32 @@
 	font-weight: 600;
 	text-align: center;
 	text-decoration: none;
+	opacity: 1;
+	transition: opacity 0.3s ease-in-out;
 	clip-path: none;
 }
 
-.skip-to-top {
+@media (prefers-reduced-motion: reduce) {
+	.chat-box .skip-link {
+		transition: none;
+	}
+}
+
+.chat-box .skip-link.skip-to-top {
 	top: -1.5rem;
 }
 
-.skip-to-bottom {
+.chat-box .skip-link.skip-to-bottom {
 	top: 0.125rem;
 }
 
-.skip-link:not(:focus, :active) {
+.chat-box .skip-link:not(:focus, :active) {
 	position: absolute;
 	overflow: hidden;
 	width: 1px;
 	height: 1px;
 	white-space: nowrap;
+	opacity: 0;
 	clip-path: inset(50%);
 }
 

--- a/frontend/src/components/ChatBox/ChatBox.css
+++ b/frontend/src/components/ChatBox/ChatBox.css
@@ -70,27 +70,7 @@
 
 .skip-link {
 	position: absolute;
-	overflow: hidden;
-	clip: rect(0 0 0 0);
-	width: 1px;
-	padding: 0;
-	border: 0;
-	white-space: nowrap;
-	clip-path: inset(50%);
-}
-
-.skip-to-top:focus {
-	top: -1.5rem;
 	left: 0;
-}
-
-.skip-to-bottom:focus {
-	top: 0.125rem;
-	top: 0;
-}
-
-.skip-link:focus {
-	position: absolute;
 	clip: auto;
 	width: 100%;
 	height: auto;
@@ -102,6 +82,23 @@
 	text-align: center;
 	text-decoration: none;
 	clip-path: none;
+}
+
+.skip-to-top {
+	top: -1.5rem;
+}
+
+.skip-to-bottom {
+	top: 0.125rem;
+}
+
+.skip-link:not(:focus, :active) {
+	position: absolute;
+	overflow: hidden;
+	width: 1px;
+	height: 1px;
+	white-space: nowrap;
+	clip-path: inset(50%);
 }
 
 @media only screen and (width <= 70.5rem) {

--- a/frontend/src/components/ChatBox/ChatBox.css
+++ b/frontend/src/components/ChatBox/ChatBox.css
@@ -81,7 +81,7 @@
 	text-align: center;
 	text-decoration: none;
 	opacity: 1;
-	transition: opacity 0.3s ease-in-out;
+	transition: opacity 0.2s ease-in-out;
 	clip-path: none;
 }
 
@@ -105,7 +105,7 @@
 	width: 1px;
 	height: 1px;
 	white-space: nowrap;
-	opacity: 0;
+	opacity: 0.1;
 	clip-path: inset(50%);
 }
 

--- a/frontend/src/components/ChatBox/ChatBox.css
+++ b/frontend/src/components/ChatBox/ChatBox.css
@@ -5,6 +5,7 @@
 	justify-content: flex-end;
 	width: 100%;
 	height: 100%;
+	/* background-color: yellow; */
 }
 
 .chat-box .footer {
@@ -65,6 +66,10 @@
 
 .chat-box .footer .control-buttons > :focus-visible {
 	outline-offset: 0.1rem;
+}
+
+.skip-to-bottom:focus {
+	outline: 0.25rem solid var(--accent-border-colour);
 }
 
 @media only screen and (width <= 70.5rem) {

--- a/frontend/src/components/ChatBox/ChatBox.css
+++ b/frontend/src/components/ChatBox/ChatBox.css
@@ -1,21 +1,21 @@
 .chat-box {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
 	justify-content: flex-end;
 	width: 100%;
 	height: 100%;
-	/* background-color: yellow; */
 }
 
 .chat-box .footer {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	gap: 1.25rem;
 	box-sizing: border-box;
 	width: 100%;
-	padding: 0.5rem 2rem 1.5rem;
-	padding: 2rem;
+	padding: 1rem 2rem;
 }
 
 .chat-box .footer label {
@@ -68,8 +68,40 @@
 	outline-offset: 0.1rem;
 }
 
+.skip-link {
+	position: absolute;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	width: 1px;
+	padding: 0;
+	border: 0;
+	white-space: nowrap;
+	clip-path: inset(50%);
+}
+
+.skip-to-top:focus {
+	top: -1.5rem;
+	left: 0;
+}
+
 .skip-to-bottom:focus {
-	outline: 0.25rem solid var(--accent-border-colour);
+	top: 0.125rem;
+	top: 0;
+}
+
+.skip-link:focus {
+	position: absolute;
+	clip: auto;
+	width: 100%;
+	height: auto;
+	padding: 0.5rem 0;
+	background-color: var(--accent-background-colour);
+	color: var(--main-text-colour);
+	outline-offset: -0.25rem;
+	font-weight: 600;
+	text-align: center;
+	text-decoration: none;
+	clip-path: none;
 }
 
 @media only screen and (width <= 70.5rem) {

--- a/frontend/src/components/ChatBox/ChatBox.tsx
+++ b/frontend/src/components/ChatBox/ChatBox.tsx
@@ -210,12 +210,22 @@ function ChatBox({
 
 	return (
 		<div className="chat-box" id="chat-box">
-			<a href="#chat-box-input" className="skip-to-bottom" id="skip-to-bottom">skip to chat input</a>
-			{/* <button className="skip-to-bottom" id="skip-to-bottom" onClick={focusOnSkipToTop}>skip to chat input</button> */}
+			<a
+				className="skip-to-bottom skip-link "
+				id="skip-to-bottom"
+				href="#chat-box-input"
+			>
+				<span aria-hidden>&#129035;&nbsp;</span>skip to chat input
+			</a>
 			<ChatBoxFeed messages={messages} />
-			<a href="#skip-to-bottom" className="skip-top-top" id="skip-to-top">skip to top of chat</a>
-			{/* <button className="skip-top-top" onClick={focusOnSkipToBottom}>skip to top of chat</button> */}
 			<div className="footer">
+				<a
+					className="skip-to-top skip-link "
+					id="skip-to-top"
+					href="#skip-to-bottom"
+				>
+					<span aria-hidden>&#129033;&nbsp;</span>skip to top of chat
+				</a>
 				<div className="messages">
 					<ChatBoxInput
 						content={chatInput}

--- a/frontend/src/components/ChatBox/ChatBox.tsx
+++ b/frontend/src/components/ChatBox/ChatBox.tsx
@@ -200,9 +200,21 @@ function ChatBox({
 		resetRecallToLatest();
 	}
 
+	// function focusOnSkipToBottom() {
+	// 	document.getElementById('skip-to-bottom')?.focus();
+	// }
+
+	// function focusOnSkipToTop() {
+	// 	document.getElementById('skip-to-top')?.focus();
+	// }
+
 	return (
-		<div className="chat-box">
+		<div className="chat-box" id="chat-box">
+			<a href="#chat-box-input" className="skip-to-bottom" id="skip-to-bottom">skip to chat input</a>
+			{/* <button className="skip-to-bottom" id="skip-to-bottom" onClick={focusOnSkipToTop}>skip to chat input</button> */}
 			<ChatBoxFeed messages={messages} />
+			<a href="#skip-to-bottom" className="skip-top-top" id="skip-to-top">skip to top of chat</a>
+			{/* <button className="skip-top-top" onClick={focusOnSkipToBottom}>skip to top of chat</button> */}
 			<div className="footer">
 				<div className="messages">
 					<ChatBoxInput

--- a/frontend/src/components/ChatBox/ChatBox.tsx
+++ b/frontend/src/components/ChatBox/ChatBox.tsx
@@ -200,14 +200,6 @@ function ChatBox({
 		resetRecallToLatest();
 	}
 
-	// function focusOnSkipToBottom() {
-	// 	document.getElementById('skip-to-bottom')?.focus();
-	// }
-
-	// function focusOnSkipToTop() {
-	// 	document.getElementById('skip-to-top')?.focus();
-	// }
-
 	return (
 		<div className="chat-box" id="chat-box">
 			<a
@@ -219,11 +211,7 @@ function ChatBox({
 			</a>
 			<ChatBoxFeed messages={messages} />
 			<div className="footer">
-				<a
-					className="skip-to-top skip-link "
-					id="skip-to-top"
-					href="#skip-to-bottom"
-				>
+				<a className="skip-to-top skip-link " href="#skip-to-bottom">
 					<span aria-hidden>&#129033;&nbsp;</span>skip to top of chat
 				</a>
 				<div className="messages">

--- a/frontend/src/components/ChatBox/ChatBoxFeed.tsx
+++ b/frontend/src/components/ChatBox/ChatBoxFeed.tsx
@@ -22,7 +22,6 @@ function ChatBoxFeed({ messages }: { messages: ChatMessage[] }) {
 			className="chat-box-feed"
 			ref={chatboxFeedContainer}
 			aria-live="polite"
-			id="chat-box-feed"
 		>
 			{[...messages].map((message, index) => {
 				if (

--- a/frontend/src/components/ChatBox/ChatBoxFeed.tsx
+++ b/frontend/src/components/ChatBox/ChatBoxFeed.tsx
@@ -22,6 +22,7 @@ function ChatBoxFeed({ messages }: { messages: ChatMessage[] }) {
 			className="chat-box-feed"
 			ref={chatboxFeedContainer}
 			aria-live="polite"
+			id="chat-box-feed"
 		>
 			{[...messages].map((message, index) => {
 				if (

--- a/frontend/src/components/ChatBox/ChatBoxInput.tsx
+++ b/frontend/src/components/ChatBox/ChatBoxInput.tsx
@@ -60,6 +60,7 @@ function ChatBoxInput({
 				characterLimit={CHARACTER_LIMIT}
 				// eslint-disable-next-line jsx-a11y/no-autofocus
 				autoFocus={true}
+				id="chat-box-input"
 			/>
 		</label>
 	);


### PR DESCRIPTION
## Description
Added two skip links, which are visually hidden until you tab to them. 
Skip link 1 is at the beginning of the chatbox, which brings you to the chat input.
Skip link 2 is just above the chat input and brings you to skip link 1. 

## Screenshots
Skip link 1: 
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/14cd5d6f-d712-4b38-843b-b80849726d65)
Skip link 2:
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/5defa463-b29a-49fc-9537-5a08e18a925d)

GIVEN The the keyboard focus is on the chat input
WHEN the user tabs to the previous element (shift + tab)
THEN the "skip to top of chat" skip link shows up

WHEN the user activates that link (enter)
THEN the keyboard focus jumps to the "skip to chat input" skip link at the top of the chatbox

WHEN the user activates that link (enter)
THEN the keyboard focus jumps to the chat input

WHEN the keyboard focus is not on the skip links
THEN the skip links are not visible

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
