### PR TITLE
785 colour contrast readonly and placeholder text

### DIFF
--- a/frontend/src/Theme.css
+++ b/frontend/src/Theme.css
@@ -36,7 +36,7 @@
 	--level-button-colour: var(--accent-background-colour);
 	--level-button-colour-disabled: #8c8c8c;
 	--level-button-border-colour: var(--accent-border-colour);
-	--level-button-border-colour-disabled: #aaaaaa80;
+	--level-button-border-colour-disabled: #8c8c8c;
 	--level-button-background-colour-selected: var(--main-text-colour);
 	--level-button-background-colour-hover: #11484b;
 

--- a/frontend/src/Theme.css
+++ b/frontend/src/Theme.css
@@ -34,7 +34,7 @@
 
 	/* level buttons */
 	--level-button-colour: var(--accent-background-colour);
-	--level-button-colour-disabled: #777;
+	--level-button-colour-disabled: #8c8c8c;
 	--level-button-border-colour: var(--accent-border-colour);
 	--level-button-border-colour-disabled: #aaaaaa80;
 	--level-button-background-colour-selected: var(--main-text-colour);
@@ -50,7 +50,7 @@
 	--main-input-active-background-colour: var(--header-background-colour);
 	--main-input-active-text-colour: var(--main-text-colour);
 	--main-input-inactive-background-colour: #b3b3b3;
-	--main-input-inactive-text-colour: #464646;
+	--main-input-inactive-text-colour: #6b6b6b;
 
 	/* toggle switch */
 	--main-toggle-ball-colour: #ececec;

--- a/frontend/src/components/ThemedInput/ThemedInput.css
+++ b/frontend/src/components/ThemedInput/ThemedInput.css
@@ -7,6 +7,8 @@
 	border-radius: 0.25rem;
 	background-color: var(--main-input-active-background-colour);
 	color: var(--main-input-active-text-colour);
+
+	/* must inherit to override default styling */
 	font-size: inherit;
 	font-family: inherit;
 }

--- a/frontend/src/components/ThemedInput/ThemedInput.css
+++ b/frontend/src/components/ThemedInput/ThemedInput.css
@@ -7,8 +7,6 @@
 	border-radius: 0.25rem;
 	background-color: var(--main-input-active-background-colour);
 	color: var(--main-input-active-text-colour);
-
-	/* must inherit to override default styling */
 	font-size: inherit;
 	font-family: inherit;
 }
@@ -16,6 +14,11 @@
 .themed-input.disabled {
 	background-color: var(--chat-button-background-colour);
 	color: var(--main-input-inactive-text-colour);
+}
+
+.themed-input::placeholder {
+	color: var(--main-input-inactive-text-colour);
+	opacity: 1;
 }
 
 .invalid-input {


### PR DESCRIPTION
# Description
Ensure all color contrast passes, including disabled buttons,  readOnly fields (e.g. config inputs) and placeholder text (e.g. chat input). Closes #785 

## Screenshots
![Image](https://github.com/ScottLogic/prompt-injection/assets/125262707/ab0c134a-4603-4363-87ce-f78b42ff5275)
![Image](https://github.com/ScottLogic/prompt-injection/assets/125262707/0fa34269-93f7-42c3-84ec-e297aecb61f9)
![Image](https://github.com/ScottLogic/prompt-injection/assets/125262707/43f2937d-2a58-4fbe-af14-a7b5e93b4e09)

## Additional context
Colour contrast issues for placeholder text are easily missed by automated tools, but colour contrast ratios should still pass for placeholder text and inactive input text.

## Notes
- adjusted the --main-input-inactive-text-colour to pass but be less close to black
- adjusted the --level-button-colour-disabled colour to provide better contrast (it technically passed before because the text is bold, but just nudging it to also pass 4.5:1).
- Added placeholder pseudo selector to css to adjust textinput placeholder text colour

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
