### PR TITLE
853: Service availability in AWS

### DIFF
--- a/cloud/.eslintrc.cjs
+++ b/cloud/.eslintrc.cjs
@@ -15,6 +15,7 @@ module.exports = {
 	root: true,
 	ignorePatterns: ['node_modules', 'cdk.out'],
 	rules: {
+		'@typescript-eslint/consistent-type-definitions': ['error', 'type'],
 		'@typescript-eslint/init-declarations': 'error',
 		'@typescript-eslint/no-misused-promises': [
 			'error',

--- a/cloud/lib/startStopServiceLambda.ts
+++ b/cloud/lib/startStopServiceLambda.ts
@@ -1,0 +1,24 @@
+import { ECS } from '@aws-sdk/client-ecs';
+
+export type ServiceEventLambda = {
+	operation: 'start' | 'stop';
+};
+
+export const handler = async (event: ServiceEventLambda) => {
+	const { operation } = event;
+	const { CLUSTER_NAME, SERVICE_NAME } = process.env;
+	const operationDesc = operation === 'start' ? 'started' : 'stopped';
+	const ecs = new ECS();
+
+	try {
+		await ecs.updateService({
+			cluster: CLUSTER_NAME,
+			service: SERVICE_NAME,
+			desiredCount: operation === 'start' ? 1 : 0,
+		});
+		console.log(`${SERVICE_NAME} was ${operationDesc}`);
+	} catch (err) {
+		console.log(`${SERVICE_NAME} could not be ${operationDesc}`);
+		console.warn(err);
+	}
+};

--- a/cloud/package-lock.json
+++ b/cloud/package-lock.json
@@ -8,7 +8,10 @@
 			"name": "cloud",
 			"version": "0.1.0",
 			"dependencies": {
-				"aws-cdk-lib": "^2.127.0",
+				"@aws-cdk/aws-scheduler-alpha": "^2.131.0-alpha.0",
+				"@aws-cdk/aws-scheduler-targets-alpha": "^2.131.0-alpha.0",
+				"@aws-sdk/client-ecs": "^3.525.0",
+				"aws-cdk-lib": "^2.131.0",
 				"constructs": "^10.3.0",
 				"dotenv": "^16.4.4",
 				"source-map-support": "^0.5.21"
@@ -21,7 +24,7 @@
 				"@types/source-map-support": "^0.5.10",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
 				"@typescript-eslint/parser": "^6.21.0",
-				"aws-cdk": "^2.127.0",
+				"aws-cdk": "^2.131.0",
 				"concurrently": "^8.2.2",
 				"eslint": "^8.56.0",
 				"prettier": "^3.2.5",
@@ -52,6 +55,643 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
 			"integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+		},
+		"node_modules/@aws-cdk/aws-scheduler-alpha": {
+			"version": "2.131.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/aws-scheduler-alpha/-/aws-scheduler-alpha-2.131.0-alpha.0.tgz",
+			"integrity": "sha512-b/7WvX9eDk7nsujrfYVhliHRvMbag9zBWTBGR3hFFdPAMBnQKheuXiB7eZ4t6gtywno0OiT65StGA4ROaxYGcA==",
+			"engines": {
+				"node": ">= 14.15.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.131.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-cdk/aws-scheduler-targets-alpha": {
+			"version": "2.131.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/aws-scheduler-targets-alpha/-/aws-scheduler-targets-alpha-2.131.0-alpha.0.tgz",
+			"integrity": "sha512-tETgjAaMQRnBidzpUmPO6mnOzq4VYhrfu1vgIiwssG5TGCQRex2XSYYUelmH34eWbENfcG5wkxSCG7F/TzTgYg==",
+			"engines": {
+				"node": ">= 14.15.0"
+			},
+			"peerDependencies": {
+				"@aws-cdk/aws-scheduler-alpha": "2.131.0-alpha.0",
+				"aws-cdk-lib": "^2.131.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+			"integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+			"dependencies": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/crc32/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/ie11-detection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+			"dependencies": {
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+			"dependencies": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-sdk/client-ecs": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.525.0.tgz",
+			"integrity": "sha512-+uT2yuKdBL5+XGtBEecYIt3d5Trev8vbY8j3taT28CEBVKgBMCsrHJjkaAbeMcz3MYB9+KNuNYlX8FRjqJWz7g==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.525.0",
+				"@aws-sdk/core": "3.525.0",
+				"@aws-sdk/credential-provider-node": "3.525.0",
+				"@aws-sdk/middleware-host-header": "3.523.0",
+				"@aws-sdk/middleware-logger": "3.523.0",
+				"@aws-sdk/middleware-recursion-detection": "3.523.0",
+				"@aws-sdk/middleware-user-agent": "3.525.0",
+				"@aws-sdk/region-config-resolver": "3.525.0",
+				"@aws-sdk/types": "3.523.0",
+				"@aws-sdk/util-endpoints": "3.525.0",
+				"@aws-sdk/util-user-agent-browser": "3.523.0",
+				"@aws-sdk/util-user-agent-node": "3.525.0",
+				"@smithy/config-resolver": "^2.1.4",
+				"@smithy/core": "^1.3.5",
+				"@smithy/fetch-http-handler": "^2.4.3",
+				"@smithy/hash-node": "^2.1.3",
+				"@smithy/invalid-dependency": "^2.1.3",
+				"@smithy/middleware-content-length": "^2.1.3",
+				"@smithy/middleware-endpoint": "^2.4.4",
+				"@smithy/middleware-retry": "^2.1.4",
+				"@smithy/middleware-serde": "^2.1.3",
+				"@smithy/middleware-stack": "^2.1.3",
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/node-http-handler": "^2.4.1",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"@smithy/url-parser": "^2.1.3",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.4",
+				"@smithy/util-defaults-mode-node": "^2.2.3",
+				"@smithy/util-endpoints": "^1.1.4",
+				"@smithy/util-middleware": "^2.1.3",
+				"@smithy/util-retry": "^2.1.3",
+				"@smithy/util-utf8": "^2.1.1",
+				"@smithy/util-waiter": "^2.1.3",
+				"tslib": "^2.5.0",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ecs/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.525.0.tgz",
+			"integrity": "sha512-6KwGQWFoNLH1UupdWPFdKPfTgjSz1kN8/r8aCzuvvXBe4Pz+iDUZ6FEJzGWNc9AapjvZDNO1hs23slomM9rTaA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.525.0",
+				"@aws-sdk/middleware-host-header": "3.523.0",
+				"@aws-sdk/middleware-logger": "3.523.0",
+				"@aws-sdk/middleware-recursion-detection": "3.523.0",
+				"@aws-sdk/middleware-user-agent": "3.525.0",
+				"@aws-sdk/region-config-resolver": "3.525.0",
+				"@aws-sdk/types": "3.523.0",
+				"@aws-sdk/util-endpoints": "3.525.0",
+				"@aws-sdk/util-user-agent-browser": "3.523.0",
+				"@aws-sdk/util-user-agent-node": "3.525.0",
+				"@smithy/config-resolver": "^2.1.4",
+				"@smithy/core": "^1.3.5",
+				"@smithy/fetch-http-handler": "^2.4.3",
+				"@smithy/hash-node": "^2.1.3",
+				"@smithy/invalid-dependency": "^2.1.3",
+				"@smithy/middleware-content-length": "^2.1.3",
+				"@smithy/middleware-endpoint": "^2.4.4",
+				"@smithy/middleware-retry": "^2.1.4",
+				"@smithy/middleware-serde": "^2.1.3",
+				"@smithy/middleware-stack": "^2.1.3",
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/node-http-handler": "^2.4.1",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"@smithy/url-parser": "^2.1.3",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.4",
+				"@smithy/util-defaults-mode-node": "^2.2.3",
+				"@smithy/util-endpoints": "^1.1.4",
+				"@smithy/util-middleware": "^2.1.3",
+				"@smithy/util-retry": "^2.1.3",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.525.0.tgz",
+			"integrity": "sha512-zz13k/6RkjPSLmReSeGxd8wzGiiZa4Odr2Tv3wTcxClM4wOjD+zOgGv4Fe32b9AMqaueiCdjbvdu7AKcYxFA4A==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.525.0",
+				"@aws-sdk/core": "3.525.0",
+				"@aws-sdk/middleware-host-header": "3.523.0",
+				"@aws-sdk/middleware-logger": "3.523.0",
+				"@aws-sdk/middleware-recursion-detection": "3.523.0",
+				"@aws-sdk/middleware-user-agent": "3.525.0",
+				"@aws-sdk/region-config-resolver": "3.525.0",
+				"@aws-sdk/types": "3.523.0",
+				"@aws-sdk/util-endpoints": "3.525.0",
+				"@aws-sdk/util-user-agent-browser": "3.523.0",
+				"@aws-sdk/util-user-agent-node": "3.525.0",
+				"@smithy/config-resolver": "^2.1.4",
+				"@smithy/core": "^1.3.5",
+				"@smithy/fetch-http-handler": "^2.4.3",
+				"@smithy/hash-node": "^2.1.3",
+				"@smithy/invalid-dependency": "^2.1.3",
+				"@smithy/middleware-content-length": "^2.1.3",
+				"@smithy/middleware-endpoint": "^2.4.4",
+				"@smithy/middleware-retry": "^2.1.4",
+				"@smithy/middleware-serde": "^2.1.3",
+				"@smithy/middleware-stack": "^2.1.3",
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/node-http-handler": "^2.4.1",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"@smithy/url-parser": "^2.1.3",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.4",
+				"@smithy/util-defaults-mode-node": "^2.2.3",
+				"@smithy/util-endpoints": "^1.1.4",
+				"@smithy/util-middleware": "^2.1.3",
+				"@smithy/util-retry": "^2.1.3",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.525.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sts": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.525.0.tgz",
+			"integrity": "sha512-a8NUGRvO6rkfTZCbMaCsjDjLbERCwIUU9dIywFYcRgbFhkupJ7fSaZz3Het98U51M9ZbTEpaTa3fz0HaJv8VJw==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.525.0",
+				"@aws-sdk/middleware-host-header": "3.523.0",
+				"@aws-sdk/middleware-logger": "3.523.0",
+				"@aws-sdk/middleware-recursion-detection": "3.523.0",
+				"@aws-sdk/middleware-user-agent": "3.525.0",
+				"@aws-sdk/region-config-resolver": "3.525.0",
+				"@aws-sdk/types": "3.523.0",
+				"@aws-sdk/util-endpoints": "3.525.0",
+				"@aws-sdk/util-user-agent-browser": "3.523.0",
+				"@aws-sdk/util-user-agent-node": "3.525.0",
+				"@smithy/config-resolver": "^2.1.4",
+				"@smithy/core": "^1.3.5",
+				"@smithy/fetch-http-handler": "^2.4.3",
+				"@smithy/hash-node": "^2.1.3",
+				"@smithy/invalid-dependency": "^2.1.3",
+				"@smithy/middleware-content-length": "^2.1.3",
+				"@smithy/middleware-endpoint": "^2.4.4",
+				"@smithy/middleware-retry": "^2.1.4",
+				"@smithy/middleware-serde": "^2.1.3",
+				"@smithy/middleware-stack": "^2.1.3",
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/node-http-handler": "^2.4.1",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"@smithy/url-parser": "^2.1.3",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.4",
+				"@smithy/util-defaults-mode-node": "^2.2.3",
+				"@smithy/util-endpoints": "^1.1.4",
+				"@smithy/util-middleware": "^2.1.3",
+				"@smithy/util-retry": "^2.1.3",
+				"@smithy/util-utf8": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.525.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.525.0.tgz",
+			"integrity": "sha512-E3LtEtMWCriQOFZpVKpLYzbdw/v2PAOEAMhn2VRRZ1g0/g1TXzQrfhEU2yd8l/vQEJaCJ82ooGGg7YECviBUxA==",
+			"dependencies": {
+				"@smithy/core": "^1.3.5",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/signature-v4": "^2.1.3",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.523.0.tgz",
+			"integrity": "sha512-Y6DWdH6/OuMDoNKVzZlNeBc6f1Yjk1lYMjANKpIhMbkRCvLJw/PYZKOZa8WpXbTYdgg9XLjKybnLIb3ww3uuzA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.525.0.tgz",
+			"integrity": "sha512-RNWQGuSBQZhl3iqklOslUEfQ4br1V3DCPboMpeqFtddUWJV3m2u2extFur9/4Uy+1EHVF120IwZUKtd8dF+ibw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/fetch-http-handler": "^2.4.3",
+				"@smithy/node-http-handler": "^2.4.1",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-stream": "^2.1.3",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.525.0.tgz",
+			"integrity": "sha512-JDnccfK5JRb9jcgpc9lirL9PyCwGIqY0nKdw3LlX5WL5vTpTG4E1q7rLAlpNh7/tFD1n66Itarfv2tsyHMIqCw==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.525.0",
+				"@aws-sdk/credential-provider-env": "3.523.0",
+				"@aws-sdk/credential-provider-process": "3.523.0",
+				"@aws-sdk/credential-provider-sso": "3.525.0",
+				"@aws-sdk/credential-provider-web-identity": "3.525.0",
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/credential-provider-imds": "^2.2.3",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/shared-ini-file-loader": "^2.3.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.525.0.tgz",
+			"integrity": "sha512-RJXlO8goGXpnoHQAyrCcJ0QtWEOFa34LSbfdqBIjQX/fwnjUuEmiGdXTV3AZmwYQ7juk49tfBneHbtOP3AGqsQ==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.523.0",
+				"@aws-sdk/credential-provider-http": "3.525.0",
+				"@aws-sdk/credential-provider-ini": "3.525.0",
+				"@aws-sdk/credential-provider-process": "3.523.0",
+				"@aws-sdk/credential-provider-sso": "3.525.0",
+				"@aws-sdk/credential-provider-web-identity": "3.525.0",
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/credential-provider-imds": "^2.2.3",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/shared-ini-file-loader": "^2.3.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.523.0.tgz",
+			"integrity": "sha512-f0LP9KlFmMvPWdKeUKYlZ6FkQAECUeZMmISsv6NKtvPCI9e4O4cLTeR09telwDK8P0HrgcRuZfXM7E30m8re0Q==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/shared-ini-file-loader": "^2.3.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.525.0.tgz",
+			"integrity": "sha512-7V7ybtufxdD3plxeIeB6aqHZeFIUlAyPphXIUgXrGY10iNcosL970rQPBeggsohe4gCM6UvY2TfMeEcr+ZE8FA==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.525.0",
+				"@aws-sdk/token-providers": "3.525.0",
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/shared-ini-file-loader": "^2.3.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.525.0.tgz",
+			"integrity": "sha512-sAukOjR1oKb2JXG4nPpuBFpSwGUhrrY17PG/xbTy8NAoLLhrqRwnErcLfdTfmj6tH+3094k6ws/Sh8a35ae7fA==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.525.0",
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.523.0.tgz",
+			"integrity": "sha512-4g3q7Ta9sdD9TMUuohBAkbx/e3I/juTqfKi7TPgP+8jxcYX72MOsgemAMHuP6CX27eyj4dpvjH+w4SIVDiDSmg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.523.0.tgz",
+			"integrity": "sha512-PeDNJNhfiaZx54LBaLTXzUaJ9LXFwDFFIksipjqjvxMafnoVcQwKbkoPUWLe5ytT4nnL1LogD3s55mERFUsnwg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.523.0.tgz",
+			"integrity": "sha512-nZ3Vt7ehfSDYnrcg/aAfjjvpdE+61B3Zk68i6/hSUIegT3IH9H1vSW67NDKVp+50hcEfzWwM2HMPXxlzuyFyrw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.525.0.tgz",
+			"integrity": "sha512-4al/6uO+t/QIYXK2OgqzDKQzzLAYJza1vWFS+S0lJ3jLNGyLB5BMU5KqWjDzevYZ4eCnz2Nn7z0FveUTNz8YdQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@aws-sdk/util-endpoints": "3.525.0",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.525.0.tgz",
+			"integrity": "sha512-8kFqXk6UyKgTMi7N7QlhA6qM4pGPWbiUXqEY2RgUWngtxqNFGeM9JTexZeuavQI+qLLe09VPShPNX71fEDcM6w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.3",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.525.0.tgz",
+			"integrity": "sha512-puVjbxuK0Dq7PTQ2HdddHy2eQjOH8GZbump74yWJa6JVpRW84LlOcNmP+79x4Kscvz2ldWB8XDFw/pcCiSDe5A==",
+			"dependencies": {
+				"@aws-sdk/client-sso-oidc": "3.525.0",
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/shared-ini-file-loader": "^2.3.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+			"integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.525.0.tgz",
+			"integrity": "sha512-DIW7WWU5tIGkeeKX6NJUyrEIdWMiqjLQG3XBzaUj+ufIENwNjdAHhlD8l2vX7Yr3JZRT6yN/84wBCj7Tw1xd1g==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-endpoints": "^1.1.4",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.495.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.495.0.tgz",
+			"integrity": "sha512-MfaPXT0kLX2tQaR90saBT9fWQq2DHqSSJRzW+MZWsmF+y5LGCOhO22ac/2o6TKSQm7h0HRc2GaADqYYYor62yg==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.523.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.523.0.tgz",
+			"integrity": "sha512-6ZRNdGHX6+HQFqTbIA5+i8RWzxFyxsZv8D3soRfpdyWIKkzhSz8IyRKXRciwKBJDaC7OX2jzGE90wxRQft27nA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/types": "^2.10.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.525.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.525.0.tgz",
+			"integrity": "sha512-88Wjt4efyUSBGcyIuh1dvoMqY1k15jpJc5A/3yi67clBQEFsu9QCodQCQPqmRjV3VRcMtBOk+jeCTiUzTY5dRQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.523.0",
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/util-utf8-browser": {
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+			"dependencies": {
+				"tslib": "^2.3.1"
+			}
 		},
 		"node_modules/@babel/runtime": {
 			"version": "7.23.9",
@@ -224,6 +864,549 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@smithy/abort-controller": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
+			"integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/config-resolver": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.4.tgz",
+			"integrity": "sha512-AW2WUZmBAzgO3V3ovKtsUbI3aBNMeQKFDumoqkNxaVDWF/xfnxAWqBKDr/NuG7c06N2Rm4xeZLPiJH/d+na0HA==",
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.3",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/core": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.5.tgz",
+			"integrity": "sha512-Rrc+e2Jj6Gu7Xbn0jvrzZlSiP2CZocIOfZ9aNUA82+1sa6GBnxqL9+iZ9EKHeD9aqD1nU8EK4+oN2EiFpSv7Yw==",
+			"dependencies": {
+				"@smithy/middleware-endpoint": "^2.4.4",
+				"@smithy/middleware-retry": "^2.1.4",
+				"@smithy/middleware-serde": "^2.1.3",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-middleware": "^2.1.3",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.4.tgz",
+			"integrity": "sha512-DdatjmBZQnhGe1FhI8gO98f7NmvQFSDiZTwC3WMvLTCKQUY+Y1SVkhJqIuLu50Eb7pTheoXQmK+hKYUgpUWsNA==",
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"@smithy/url-parser": "^2.1.3",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
+			"integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
+			"dependencies": {
+				"@aws-crypto/crc32": "3.0.0",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.3.tgz",
+			"integrity": "sha512-Fn/KYJFo6L5I4YPG8WQb2hOmExgRmNpVH5IK2zU3JKrY5FKW7y9ar5e0BexiIC9DhSKqKX+HeWq/Y18fq7Dkpw==",
+			"dependencies": {
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/querystring-builder": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-base64": "^2.1.1",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.3.tgz",
+			"integrity": "sha512-FsAPCUj7VNJIdHbSxMd5uiZiF20G2zdSDgrgrDrHqIs/VMxK85Vqk5kMVNNDMCZmMezp6UKnac0B4nAyx7HJ9g==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-buffer-from": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.3.tgz",
+			"integrity": "sha512-wkra7d/G4CbngV4xsjYyAYOvdAhahQje/WymuQdVEnXFExJopEu7fbL5AEAlBPgWHXwu94VnCSG00gVzRfExyg==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+			"integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.3.tgz",
+			"integrity": "sha512-aJduhkC+dcXxdnv5ZpM3uMmtGmVFKx412R1gbeykS5HXDmRU6oSsyy2SoHENCkfOGKAQOjVE2WVqDJibC0d21g==",
+			"dependencies": {
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.4.tgz",
+			"integrity": "sha512-4yjHyHK2Jul4JUDBo2sTsWY9UshYUnXeb/TAK/MTaPEb8XQvDmpwSFnfIRDU45RY1a6iC9LCnmJNg/yHyfxqkw==",
+			"dependencies": {
+				"@smithy/middleware-serde": "^2.1.3",
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/shared-ini-file-loader": "^2.3.4",
+				"@smithy/types": "^2.10.1",
+				"@smithy/url-parser": "^2.1.3",
+				"@smithy/util-middleware": "^2.1.3",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.4.tgz",
+			"integrity": "sha512-Cyolv9YckZTPli1EkkaS39UklonxMd08VskiuMhURDjC0HHa/AD6aK/YoD21CHv9s0QLg0WMLvk9YeLTKkXaFQ==",
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/service-error-classification": "^2.1.3",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-middleware": "^2.1.3",
+				"@smithy/util-retry": "^2.1.3",
+				"tslib": "^2.5.0",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.3.tgz",
+			"integrity": "sha512-s76LId+TwASrHhUa9QS4k/zeXDUAuNuddKklQzRgumbzge5BftVXHXIqL4wQxKGLocPwfgAOXWx+HdWhQk9hTg==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.3.tgz",
+			"integrity": "sha512-opMFufVQgvBSld/b7mD7OOEBxF6STyraVr1xel1j0abVILM8ALJvRoFbqSWHGmaDlRGIiV9Q5cGbWi0sdiEaLQ==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
+			"integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
+			"dependencies": {
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/shared-ini-file-loader": "^2.3.4",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.1.tgz",
+			"integrity": "sha512-HCkb94soYhJMxPCa61wGKgmeKpJ3Gftx1XD6bcWEB2wMV1L9/SkQu/6/ysKBnbOzWRE01FGzwrTxucHypZ8rdg==",
+			"dependencies": {
+				"@smithy/abort-controller": "^2.1.3",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/querystring-builder": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
+			"integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
+			"integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.3.tgz",
+			"integrity": "sha512-kFD3PnNqKELe6m9GRHQw/ftFFSZpnSeQD4qvgDB6BQN6hREHELSosVFUMPN4M3MDKN2jAwk35vXHLoDrNfKu0A==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-uri-escape": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.3.tgz",
+			"integrity": "sha512-3+CWJoAqcBMR+yvz6D+Fc5VdoGFtfenW6wqSWATWajrRMGVwJGPT3Vy2eb2bnMktJc4HU4bpjeovFa566P3knQ==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.3.tgz",
+			"integrity": "sha512-iUrpSsem97bbXHHT/v3s7vaq8IIeMo6P6cXdeYHrx0wOJpMeBGQF7CB0mbJSiTm3//iq3L55JiEm8rA7CTVI8A==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
+			"integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
+			"integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
+			"dependencies": {
+				"@smithy/eventstream-codec": "^2.1.3",
+				"@smithy/is-array-buffer": "^2.1.1",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
+				"@smithy/util-middleware": "^2.1.3",
+				"@smithy/util-uri-escape": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.2.tgz",
+			"integrity": "sha512-ntAFYN51zu3N3mCd95YFcFi/8rmvm//uX+HnK24CRbI6k5Rjackn0JhgKz5zOx/tbNvOpgQIwhSX+1EvEsBLbA==",
+			"dependencies": {
+				"@smithy/middleware-endpoint": "^2.4.4",
+				"@smithy/middleware-stack": "^2.1.3",
+				"@smithy/protocol-http": "^3.2.1",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-stream": "^2.1.3",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+			"integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/url-parser": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.3.tgz",
+			"integrity": "sha512-X1NRA4WzK/ihgyzTpeGvI9Wn45y8HmqF4AZ/FazwAv8V203Ex+4lXqcYI70naX9ETqbqKVzFk88W6WJJzCggTQ==",
+			"dependencies": {
+				"@smithy/querystring-parser": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+			"integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-browser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+			"integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-node": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+			"integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+			"integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+			"integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.4.tgz",
+			"integrity": "sha512-J6XAVY+/g7jf03QMnvqPyU+8jqGrrtXoKWFVOS+n1sz0Lg8HjHJ1ANqaDN+KTTKZRZlvG8nU5ZrJOUL6VdwgcQ==",
+			"dependencies": {
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.3.tgz",
+			"integrity": "sha512-ttUISrv1uVOjTlDa3nznX33f0pthoUlP+4grhTvOzcLhzArx8qHB94/untGACOG3nlf8vU20nI2iWImfzoLkYA==",
+			"dependencies": {
+				"@smithy/config-resolver": "^2.1.4",
+				"@smithy/credential-provider-imds": "^2.2.4",
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/property-provider": "^2.1.3",
+				"@smithy/smithy-client": "^2.4.2",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@smithy/util-endpoints": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.4.tgz",
+			"integrity": "sha512-/qAeHmK5l4yQ4/bCIJ9p49wDe9rwWtOzhPHblu386fwPNT3pxmodgcs9jDCV52yK9b4rB8o9Sj31P/7Vzka1cg==",
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.2.4",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-hex-encoding": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+			"integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-middleware": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
+			"integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
+			"dependencies": {
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-retry": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.3.tgz",
+			"integrity": "sha512-Kbvd+GEMuozbNUU3B89mb99tbufwREcyx2BOX0X2+qHjq6Gvsah8xSDDgxISDwcOHoDqUWO425F0Uc/QIRhYkg==",
+			"dependencies": {
+				"@smithy/service-error-classification": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-stream": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.3.tgz",
+			"integrity": "sha512-HvpEQbP8raTy9n86ZfXiAkf3ezp1c3qeeO//zGqwZdrfaoOpGKQgF2Sv1IqZp7wjhna7pvczWaGUHjcOPuQwKw==",
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^2.4.3",
+				"@smithy/node-http-handler": "^2.4.1",
+				"@smithy/types": "^2.10.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-buffer-from": "^2.1.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+			"integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+			"integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-waiter": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.3.tgz",
+			"integrity": "sha512-3R0wNFAQQoH9e4m+bVLDYNOst2qNxtxFgq03WoNHWTBOqQT3jFnOBRj1W51Rf563xDA5kwqjziksxn6RKkHB+Q==",
+			"dependencies": {
+				"@smithy/abort-controller": "^2.1.3",
+				"@smithy/types": "^2.10.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@tsconfig/node10": {
@@ -592,9 +1775,9 @@
 			}
 		},
 		"node_modules/aws-cdk": {
-			"version": "2.127.0",
-			"resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.127.0.tgz",
-			"integrity": "sha512-0yPiN+/VFVc/NpOryO+1S7b4DBgRSs4JdQ64jhV4QbwaoWZo7KISxdN2cK4pmcVH67BSNCJCjjlf10cYhmMvwA==",
+			"version": "2.131.0",
+			"resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.131.0.tgz",
+			"integrity": "sha512-ji+MwGFGC88HE/EqV6/VARBp5mu3nXIDa/GYwtGycJqu6WqXhNZXWeDH0JsWaY6+BSUdpY6pr6KWpV+MDyVkDg==",
 			"dev": true,
 			"bin": {
 				"cdk": "bin/cdk"
@@ -607,9 +1790,9 @@
 			}
 		},
 		"node_modules/aws-cdk-lib": {
-			"version": "2.127.0",
-			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.127.0.tgz",
-			"integrity": "sha512-pEdp2TqgNLYY+kAo68oVzMDEHJevYoRArZJoH+bjM9YTwqRJJiwF1k6tc78e3jca4sCNDZAgX2ytOgqW6lVTWQ==",
+			"version": "2.131.0",
+			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.131.0.tgz",
+			"integrity": "sha512-9XLgiTgY+q0S3K93VPeJO0chIN8BZwZ3aSrILvF868Dz+0NTNrD2m5M0xGK5Rw0uoJS+N+DvGaz/2hLAiVqcBw==",
 			"bundleDependencies": [
 				"@balena/dockerignore",
 				"case",
@@ -620,7 +1803,8 @@
 				"punycode",
 				"semver",
 				"table",
-				"yaml"
+				"yaml",
+				"mime-types"
 			],
 			"dependencies": {
 				"@aws-cdk/asset-awscli-v1": "^2.2.202",
@@ -631,9 +1815,10 @@
 				"fs-extra": "^11.2.0",
 				"ignore": "^5.3.1",
 				"jsonschema": "^1.4.1",
+				"mime-types": "^2.1.35",
 				"minimatch": "^3.1.2",
 				"punycode": "^2.3.1",
-				"semver": "^7.5.4",
+				"semver": "^7.6.0",
 				"table": "^6.8.1",
 				"yaml": "1.10.2"
 			},
@@ -821,6 +2006,25 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/aws-cdk-lib/node_modules/mime-db": {
+			"version": "1.52.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/mime-types": {
+			"version": "2.1.35",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/aws-cdk-lib/node_modules/minimatch": {
 			"version": "3.1.2",
 			"inBundle": true,
@@ -849,7 +2053,7 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/semver": {
-			"version": "7.5.4",
+			"version": "7.6.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -951,6 +2155,11 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
+		},
+		"node_modules/bowser": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -1410,6 +2619,27 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
+		"node_modules/fast-xml-parser": {
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+			"integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+			"funding": [
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
 		"node_modules/fastq": {
 			"version": "1.15.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -1594,6 +2824,7 @@
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
 			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"dev": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -2201,6 +3432,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/strnum": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2298,8 +3534,7 @@
 		"node_modules/tslib": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-			"dev": true
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -19,15 +19,18 @@
 		"@types/source-map-support": "^0.5.10",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"@typescript-eslint/parser": "^6.21.0",
+		"aws-cdk": "^2.131.0",
 		"concurrently": "^8.2.2",
 		"eslint": "^8.56.0",
-		"aws-cdk": "^2.127.0",
 		"prettier": "^3.2.5",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.3.3"
 	},
 	"dependencies": {
-		"aws-cdk-lib": "^2.127.0",
+		"@aws-cdk/aws-scheduler-alpha": "^2.131.0-alpha.0",
+		"@aws-cdk/aws-scheduler-targets-alpha": "^2.131.0-alpha.0",
+		"aws-cdk-lib": "^2.131.0",
+		"@aws-sdk/client-ecs": "^3.525.0",
 		"constructs": "^10.3.0",
 		"dotenv": "^16.4.4",
 		"source-map-support": "^0.5.21"


### PR DESCRIPTION
## Description

It came to my attention that the fargate service and associated infrastructure is costing us more than $3 a day. We can decrease that by around 70% if we bring the service down overnight, and not have the application up over weekends.

Currently there is no _trivial_ way to achieve this using CDK, although there are some alpha constructs in development which we can use, together with a lambda function, to update the service to flip "desired task count" from zero to 1 in the morning and back to zero in the evening.

Resolves #853 

## Screenshots

![image](https://github.com/ScottLogic/prompt-injection/assets/15246391/c905b6c6-e5cd-441a-a7cb-20f77196a616)

## Concerns

- We might want to show a different UI page outside of uptime hours, such as a generic "downtime / maintenance" message. I will assess how this looks once it's live in AWS, and spawn another issue if needed.

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [ ] Ensured the workflow steps are passing
