### PR TITLE
824: bugfix for level queryparam

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,8 @@
 				"memorystore": "^1.6.7",
 				"openai": "^4.19.0",
 				"openai-chat-tokens": "^0.2.8",
-				"pdf-parse": "^1.1.1"
+				"pdf-parse": "^1.1.1",
+				"query-types": "^0.1.4"
 			},
 			"devDependencies": {
 				"@jest/globals": "^29.7.0",
@@ -6846,6 +6847,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/query-types": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/query-types/-/query-types-0.1.4.tgz",
+			"integrity": "sha512-DvOCeSGI+RJeZ8+13NYTZUGbGva3P85GmATpY2ojj0mIsNfw70xeTpQW51JaYDZyQ2Li/svGT+FUdd4CBUoDcQ=="
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,8 @@
 		"memorystore": "^1.6.7",
 		"openai": "^4.19.0",
 		"openai-chat-tokens": "^0.2.8",
-		"pdf-parse": "^1.1.1"
+		"pdf-parse": "^1.1.1",
+		"query-types": "^0.1.4"
 	},
 	"devDependencies": {
 		"@jest/globals": "^29.7.0",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,11 +1,13 @@
 import cors from 'cors';
 import express from 'express';
+import queryTypes from 'query-types';
 
 import nonSessionRoutes from './nonSessionRoutes';
 import sessionRoutes from './sessionRoutes';
 
 export default express()
 	.use(express.json())
+	.use(queryTypes.middleware())
 	.use(
 		cors({
 			origin: process.env.CORS_ALLOW_ORIGIN,

--- a/backend/src/controller/startController.ts
+++ b/backend/src/controller/startController.ts
@@ -1,6 +1,9 @@
 import { Response } from 'express';
 
-import { StartGetRequest } from '@src/models/api/StartGetRequest';
+import {
+	StartGetRequest,
+	StartResponse,
+} from '@src/models/api/StartGetRequest';
 import { LEVEL_NAMES, isValidLevel } from '@src/models/level';
 import { getValidOpenAIModels } from '@src/openai';
 import {
@@ -36,7 +39,7 @@ function handleStart(req: StartGetRequest, res: Response) {
 		defences: req.session.levelState[level].defences,
 		availableModels: getValidOpenAIModels(),
 		systemRoles,
-	});
+	} as StartResponse);
 }
 
 export { handleStart };

--- a/backend/src/models/api/StartGetRequest.ts
+++ b/backend/src/models/api/StartGetRequest.ts
@@ -5,15 +5,20 @@ import { Defence } from '@src/models/defence';
 import { EmailInfo } from '@src/models/email';
 import { LEVEL_NAMES } from '@src/models/level';
 
+export type StartResponse = {
+	emails: EmailInfo[];
+	chatHistory: ChatMessage[];
+	defences: Defence[];
+	availableModels: string[];
+	systemRoles: {
+		level: LEVEL_NAMES;
+		systemRole: string;
+	}[];
+};
+
 export type StartGetRequest = Request<
 	never,
-	{
-		emails: EmailInfo[];
-		chatHistory: ChatMessage[];
-		defences: Defence[];
-		availableModels: string[];
-		systemRoles: string[];
-	},
+	StartResponse,
 	never,
 	{
 		level?: LEVEL_NAMES;

--- a/backend/test/api/start.test.ts
+++ b/backend/test/api/start.test.ts
@@ -1,13 +1,32 @@
-import { it, describe, expect } from '@jest/globals';
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { OpenAI } from 'openai';
 import request from 'supertest';
 
 import app from '@src/app';
 import { StartResponse } from '@src/models/api/StartGetRequest';
 import { LEVEL_NAMES } from '@src/models/level';
 
+jest.mock('openai');
+
 const PATH = '/start';
 
 describe('/start endpoints', () => {
+	const mockListFn = jest.fn<OpenAI.Models['list']>();
+	jest.mocked(OpenAI).mockImplementation(
+		() =>
+			({
+				models: {
+					list: mockListFn,
+				},
+			} as unknown as jest.MockedObject<OpenAI>)
+	);
+
+	beforeAll(() => {
+		mockListFn.mockResolvedValue({
+			data: [{ id: 'gpt-3.5-turbo' }],
+		} as OpenAI.ModelsPage);
+	});
+
 	it.each(Object.values(LEVEL_NAMES))(
 		'WHEN given valid level [%s] THEN it responds with 200',
 		async (level) =>

--- a/backend/test/api/start.test.ts
+++ b/backend/test/api/start.test.ts
@@ -1,0 +1,35 @@
+import { it, describe, expect } from '@jest/globals';
+import request from 'supertest';
+
+import app from '@src/app';
+import { StartResponse } from '@src/models/api/StartGetRequest';
+import { LEVEL_NAMES } from '@src/models/level';
+
+const PATH = '/start';
+
+describe('/start endpoints', () => {
+	it.each(Object.values(LEVEL_NAMES))(
+		'WHEN given valid level [%s] THEN it responds with 200',
+		async (level) =>
+			request(app)
+				.get(`${PATH}?level=${level}`)
+				.expect(200)
+				.expect('Content-Type', /application\/json/)
+				.then((response) => {
+					const { chatHistory, emails } = response.body as StartResponse;
+					expect(chatHistory).toEqual([]);
+					expect(emails).toEqual([]);
+				})
+	);
+
+	it.each([-1, 4, 'SANDBOX'])(
+		'WHEN given invalid level [%s] THEN it responds with 400',
+		async (level) =>
+			request(app)
+				.get(`${PATH}?level=${level}`)
+				.expect(400)
+				.then((response) => {
+					expect(response.text).toEqual('Invalid level');
+				})
+	);
+});

--- a/backend/test/setupEnvVars.ts
+++ b/backend/test/setupEnvVars.ts
@@ -1,2 +1,3 @@
 // set the environment variables
 process.env.OPENAI_API_KEY = 'sk-12345';
+process.env.SESSION_SECRET = "shhh! Don't tell anyone...";

--- a/backend/typings/query-types.d.ts
+++ b/backend/typings/query-types.d.ts
@@ -1,5 +1,5 @@
 declare module 'query-types' {
-	import { NextHandleFunction } from 'connect';
+	import type { NextHandleFunction } from 'connect';
 
 	function middleware(): NextHandleFunction;
 }

--- a/backend/typings/query-types.d.ts
+++ b/backend/typings/query-types.d.ts
@@ -1,0 +1,5 @@
+declare module 'query-types' {
+	import { NextHandleFunction } from 'connect';
+
+	function middleware(): NextHandleFunction;
+}


### PR DESCRIPTION
## Description

Fixes a bug in which the level param was not parsed into a number before checking, so the level endpoint always failed with 400 response.

Related to #824 and #842 

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [x] Added tests
- [x] Ensured the workflow steps are passing
