### PR TITLE
added button to show completed story modal if user accidentally clicks out of it 

### DIFF
--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -53,4 +53,23 @@ describe('LevelMissionInfoBanner component tests', () => {
 
 		expect(openOverlayMock).toHaveBeenCalled();
 	});
+
+	test('fires the openLevelsCompleteOverlay callback on button click', () => {
+		const currentLevel = LEVEL_NAMES.LEVEL_1;
+
+		const openOverlayMock = vi.fn();
+		render(
+			<LevelMissionInfoBanner
+				currentLevel={currentLevel}
+				openOverlay={openOverlayMock}
+				openLevelsCompleteOverlay={() => {}}
+				numCompletedLevels={currentLevel}
+			/>
+		);
+
+		const button = screen.getByText('congratulations!');
+		fireEvent.click(button);
+
+		expect(openOverlayMock).toHaveBeenCalled();
+	});
 });

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -67,7 +67,7 @@ describe('LevelMissionInfoBanner component tests', () => {
 			/>
 		);
 
-		const button = screen.getByText('congratulations!');
+		const button = screen.getByText('Congratulations!');
 		fireEvent.click(button);
 
 		expect(openOverlayMock).toHaveBeenCalled();

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -55,15 +55,15 @@ describe('LevelMissionInfoBanner component tests', () => {
 	});
 
 	test('fires the openLevelsCompleteOverlay callback on button click', () => {
-		const currentLevel = LEVEL_NAMES.LEVEL_1;
+		const currentLevel = LEVEL_NAMES.LEVEL_3;
 
 		const openOverlayMock = vi.fn();
 		render(
 			<LevelMissionInfoBanner
 				currentLevel={currentLevel}
-				openOverlay={openOverlayMock}
-				openLevelsCompleteOverlay={() => {}}
-				numCompletedLevels={currentLevel}
+				openOverlay={() => {}}
+				openLevelsCompleteOverlay={openOverlayMock}
+				numCompletedLevels={4}
 			/>
 		);
 

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.test.tsx
@@ -18,6 +18,8 @@ describe('LevelMissionInfoBanner component tests', () => {
 			<LevelMissionInfoBanner
 				currentLevel={currentLevel}
 				openOverlay={() => {}}
+				openLevelsCompleteOverlay={() => {}}
+				numCompletedLevels={currentLevel}
 			/>
 		);
 
@@ -41,6 +43,8 @@ describe('LevelMissionInfoBanner component tests', () => {
 			<LevelMissionInfoBanner
 				currentLevel={currentLevel}
 				openOverlay={openOverlayMock}
+				openLevelsCompleteOverlay={() => {}}
+				numCompletedLevels={currentLevel}
 			/>
 		);
 

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
@@ -15,7 +15,8 @@ function LevelMissionInfoBanner({
 	openLevelsCompleteOverlay: () => void;
 	numCompletedLevels: number;
 }) {
-	const isLevelComplete = (currentLevel as number) < numCompletedLevels;
+	const isLevelComplete = currentLevel < numCompletedLevels;
+	const isLevel3 = currentLevel === LEVEL_NAMES.LEVEL_3;
 
 	return (
 		<span className="level-mission-info-banner">
@@ -31,7 +32,7 @@ function LevelMissionInfoBanner({
 				</span>
 				Mission Info
 			</ThemedButton>
-			{isLevelComplete && (currentLevel as number) === 2 && (
+			{isLevelComplete && isLevel3 && (
 				<ThemedButton onClick={openLevelsCompleteOverlay}>
 					Congratulations
 				</ThemedButton>

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
@@ -7,10 +7,16 @@ import './LevelMissionInfoBanner.css';
 function LevelMissionInfoBanner({
 	currentLevel,
 	openOverlay,
+	openLevelsCompleteOverlay,
+	numCompletedLevels,
 }: {
 	currentLevel: LEVEL_NAMES;
 	openOverlay: () => void;
+	openLevelsCompleteOverlay: () => void;
+	numCompletedLevels: number;
 }) {
+	const isLevelComplete = (currentLevel as number) < numCompletedLevels;
+
 	return (
 		<span className="level-mission-info-banner">
 			<h2 className="level-title-area">{`Level ${currentLevel + 1}`}</h2>
@@ -25,6 +31,11 @@ function LevelMissionInfoBanner({
 				</span>
 				Mission Info
 			</ThemedButton>
+			{isLevelComplete && (currentLevel as number) === 2 && (
+				<ThemedButton onClick={openLevelsCompleteOverlay}>
+					Congratulations
+				</ThemedButton>
+			)}
 		</span>
 	);
 }

--- a/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
+++ b/frontend/src/components/LevelMissionInfoBanner/LevelMissionInfoBanner.tsx
@@ -34,7 +34,7 @@ function LevelMissionInfoBanner({
 			</ThemedButton>
 			{isLevelComplete && isLevel3 && (
 				<ThemedButton onClick={openLevelsCompleteOverlay}>
-					Congratulations
+					Congratulations!
 				</ThemedButton>
 			)}
 		</span>

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -297,6 +297,8 @@ function MainComponent({
 				<LevelMissionInfoBanner
 					currentLevel={currentLevel}
 					openOverlay={openInformationOverlay}
+					openLevelsCompleteOverlay={openLevelsCompleteOverlay}
+					numCompletedLevels={numCompletedLevels}
 				/>
 			)}
 			<MainBody


### PR DESCRIPTION
## Description
there is a congratulations modal that pops up when users complete all 3 levels. This ticket includes a button in the mission info banner to bring the win modal back up if the user clicks out of it accidentally.

## Screenshots

<img width="949" alt="image" src="https://github.com/ScottLogic/prompt-injection/assets/125262433/0f12033a-8191-4396-b2da-cd10af418d8c">


## Checklist

Have you done the following?

- [x] Linked the relevant Issue
https://github.com/ScottLogic/prompt-injection/issues/805
- [ ] Added tests
- [ ] Ensured the workflow steps are passing
