### PR TITLE
fixing radio button centering

### DIFF
--- a/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
+++ b/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
@@ -2,15 +2,12 @@
 	position: relative;
 	display: flex;
 	cursor: pointer;
+	gap: 0.75rem;
 }
 
 .defence-radio-button input {
 	margin-bottom: 0.5rem;
 	opacity: 0;
-}
-
-.defence-radio-button span {
-	margin-left: 1rem;
 }
 
 /* checkmark outer circle */

--- a/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
+++ b/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
@@ -1,9 +1,9 @@
 .defence-radio-button {
 	position: relative;
 	display: inline-block;
+	display: flex;
 	margin: 0.1rem;
 	cursor: pointer;
-	display: flex;
 }
 
 .defence-radio-button input {

--- a/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
+++ b/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
@@ -1,10 +1,12 @@
 .defence-radio-button {
 	position: relative;
 	display: inline-block;
+	margin: 0.1rem;
 	cursor: pointer;
 }
 
 .defence-radio-button input {
+	margin-bottom: 0.5rem;
 	opacity: 0;
 }
 
@@ -44,7 +46,17 @@
 .defence-radio-button input:focus + span::before {
 	box-shadow: 0 0 0 0.1rem;
 }
+
 .defence-radio-button input:focus + span::before {
 	outline: 0.25rem solid var(--accent-border-colour);
 	outline-offset: 0.125rem;
+}
+
+.defence-radio-button input:hover + span::before {
+	outline: 0.25rem solid var(--accent-border-colour);
+	outline-offset: 0.125rem;
+}
+
+.defence-radio-button span {
+	margin-top: 1rem;
 }

--- a/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
+++ b/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
@@ -11,6 +11,7 @@
 }
 
 .defence-radio-button span {
+	margin-top: 1rem;
 	margin-left: 1rem;
 }
 
@@ -44,10 +45,6 @@
 }
 
 .defence-radio-button input:focus + span::before {
-	box-shadow: 0 0 0 0.1rem;
-}
-
-.defence-radio-button input:focus + span::before {
 	outline: 0.25rem solid var(--accent-border-colour);
 	outline-offset: 0.125rem;
 }
@@ -55,8 +52,4 @@
 .defence-radio-button input:hover + span::before {
 	outline: 0.25rem solid var(--accent-border-colour);
 	outline-offset: 0.125rem;
-}
-
-.defence-radio-button span {
-	margin-top: 1rem;
 }

--- a/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
+++ b/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
@@ -1,8 +1,6 @@
 .defence-radio-button {
 	position: relative;
-	display: inline-block;
 	display: flex;
-	margin: 0.1rem;
 	cursor: pointer;
 }
 

--- a/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
+++ b/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
@@ -31,8 +31,8 @@
 .defence-radio-button input + span::after {
 	content: '';
 	position: absolute;
-	top: 0.34rem;
-	left: 0.34rem;
+	top: 0.3125rem;
+	left: 0.3125rem;
 	border: 0.3125rem solid var(--main-toggle-ball-colour);
 	border-radius: 50%;
 	opacity: 0;

--- a/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
+++ b/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
@@ -28,8 +28,8 @@
 .defence-radio-button input + span::after {
 	content: '';
 	position: absolute;
-	top: 0.3125rem;
-	left: 0.3125rem;
+	top: 0.34rem;
+	left: 0.34rem;
 	border: 0.3125rem solid var(--main-toggle-ball-colour);
 	border-radius: 50%;
 	opacity: 0;
@@ -42,5 +42,9 @@
 }
 
 .defence-radio-button input:focus + span::before {
-	box-shadow: 0 0 0 0.125rem;
+	box-shadow: 0 0 0 0.1rem;
+}
+.defence-radio-button input:focus + span::before {
+	outline: 0.25rem solid var(--accent-border-colour);
+	outline-offset: 0.125rem;
 }

--- a/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
+++ b/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
@@ -3,6 +3,7 @@
 	display: inline-block;
 	margin: 0.1rem;
 	cursor: pointer;
+	display: flex;
 }
 
 .defence-radio-button input {
@@ -11,7 +12,6 @@
 }
 
 .defence-radio-button span {
-	margin-top: 1rem;
 	margin-left: 1rem;
 }
 


### PR DESCRIPTION
## Description
added the same styling of the toggle switches to the radio buttons for focusing and hovering, recentered the selected radio button dot

## Screenshots
before
<img width="170" alt="image" src="https://github.com/ScottLogic/prompt-injection/assets/125262433/ef89596f-c296-47a4-8a07-7b70ebc7c056">

after
<img width="170" alt="image" src="https://github.com/ScottLogic/prompt-injection/assets/125262433/bebc85bb-b65a-4b8a-91f1-81eca03abde1">
<img width="230" alt="image" src="https://github.com/ScottLogic/prompt-injection/assets/125262433/f8739602-822b-4c56-abcc-500aef1ea0cd">

note: maybe text align to the left so the overflow text on the next line isn't as close to the highlight? or i could increase the margin from 0.5 to 0.6rems to give the radio button a little more space?


## Checklist

Have you done the following?

- [x] Linked the relevant Issue
https://github.com/ScottLogic/prompt-injection/issues/754
- [ ] Added tests
- [ ] Ensured the workflow steps are passing
