### PR TITLE
827 streamline network calls for reset all progress

### DIFF
--- a/backend/src/controller/resetController.ts
+++ b/backend/src/controller/resetController.ts
@@ -1,11 +1,34 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 
-import { getInitialLevelStates } from '@src/models/level';
+import { LevelGetRequest } from '@src/models/api/LevelGetRequest';
+import {
+	LEVEL_NAMES,
+	getInitialLevelStates,
+	isValidLevel,
+} from '@src/models/level';
 
-function handleResetProgress(req: Request, res: Response) {
+function handleResetProgress(req: LevelGetRequest, res: Response) {
+	const { level } = req.query;
+
+	if (level === undefined) {
+		res.status(400).send('Level not provided');
+		return;
+	}
+
+	if (!isValidLevel(level)) {
+		res.status(400).send('Invalid level');
+		return;
+	}
+
 	console.debug('Resetting progress for all levels', req.session.levelState);
 	req.session.levelState = getInitialLevelStates();
-	res.send(req.session.levelState);
+	res.send({
+		emails: req.session.levelState[level].sentEmails,
+		chatHistory: req.session.levelState[level].chatHistory,
+		defences: req.session.levelState[level].defences,
+		chatModel:
+			level === LEVEL_NAMES.SANDBOX ? req.session.chatModel : undefined,
+	});
 }
 
 export { handleResetProgress };

--- a/backend/src/controller/resetController.ts
+++ b/backend/src/controller/resetController.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 
 import { LevelGetRequest } from '@src/models/api/LevelGetRequest';
+import { defaultChatModel } from '@src/models/chat';
 import {
 	LEVEL_NAMES,
 	getInitialLevelStates,
@@ -22,6 +23,7 @@ function handleResetProgress(req: LevelGetRequest, res: Response) {
 
 	console.debug('Resetting progress for all levels', req.session.levelState);
 	req.session.levelState = getInitialLevelStates();
+	req.session.chatModel = defaultChatModel;
 	res.send({
 		emails: req.session.levelState[level].sentEmails,
 		chatHistory: req.session.levelState[level].chatHistory,

--- a/backend/test/unit/controller/levelController.test.ts
+++ b/backend/test/unit/controller/levelController.test.ts
@@ -48,6 +48,7 @@ test.each(Object.values(LEVEL_NAMES))(
 						defences: 'level 4 defences',
 					},
 				],
+				chatModel: 'chat model',
 			},
 		} as unknown as LevelGetRequest;
 		const res = responseMock();
@@ -58,6 +59,7 @@ test.each(Object.values(LEVEL_NAMES))(
 			emails: `level ${level + 1} emails`,
 			chatHistory: `level ${level + 1} chat history`,
 			defences: `level ${level + 1} defences`,
+			chatModel: level === LEVEL_NAMES.SANDBOX ? 'chat model' : undefined,
 		});
 	}
 );

--- a/backend/test/unit/controller/levelController.test.ts
+++ b/backend/test/unit/controller/levelController.test.ts
@@ -5,12 +5,6 @@ import { handleLoadLevel } from '@src/controller/levelController';
 import { LevelGetRequest } from '@src/models/api/LevelGetRequest';
 import { LEVEL_NAMES } from '@src/models/level';
 
-jest.mock('@src/promptTemplates', () => ({
-	systemRoleLevel1: 'systemRoleLevel1',
-	systemRoleLevel2: 'systemRoleLevel2',
-	systemRoleLevel3: 'systemRoleLevel3',
-}));
-
 const mockSend = jest.fn();
 
 function responseMock() {

--- a/backend/test/unit/controller/startController.test.ts
+++ b/backend/test/unit/controller/startController.test.ts
@@ -54,6 +54,7 @@ test.each(Object.values(LEVEL_NAMES))(
 						defences: 'level 4 defences',
 					},
 				],
+				chatModel: 'chat model',
 				systemRoles: [],
 			},
 		} as unknown as StartGetRequest;
@@ -71,6 +72,7 @@ test.each(Object.values(LEVEL_NAMES))(
 				{ level: 1, systemRole: 'systemRoleLevel2' },
 				{ level: 2, systemRole: 'systemRoleLevel3' },
 			],
+			chatModel: level === LEVEL_NAMES.SANDBOX ? 'chat model' : undefined,
 		});
 	}
 );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,8 +31,6 @@ function App() {
 		null
 	);
 
-	const [mainComponentKey, setMainComponentKey] = useState<number>(0);
-
 	function updateNumCompletedLevels(completedLevel: LEVEL_NAMES) {
 		setCompletedLevels(completedLevel + 1);
 	}
@@ -153,9 +151,7 @@ function App() {
 	// resets whole game progress and start from level 1 or Sandbox
 	async function resetProgress() {
 		console.log('resetting progress for all levels');
-
-		// reset on the backend
-		await resetService.resetAllLevelProgress();
+		await resetService.resetAllLevelProgress(); //yeeeeeeeee
 		resetCompletedLevels();
 
 		// set as new user so welcome modal shows
@@ -164,9 +160,6 @@ function App() {
 		// take the user to level 1 if on levels, or stay in sandbox
 		currentLevel !== LEVEL_NAMES.SANDBOX &&
 			setCurrentLevel(LEVEL_NAMES.LEVEL_1);
-
-		// re-render main component to update frontend chat & emails
-		setMainComponentKey(mainComponentKey + 1);
 	}
 
 	function goToSandbox() {
@@ -183,7 +176,6 @@ function App() {
 				<div ref={contentRef}>{overlayComponent}</div>
 			</dialog>
 			<MainComponent
-				key={mainComponentKey}
 				currentLevel={currentLevel}
 				numCompletedLevels={numCompletedLevels}
 				closeOverlay={closeOverlay}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,10 +5,8 @@ import MainComponent from './components/MainComponent/MainComponent';
 import LevelsComplete from './components/Overlay/LevelsComplete';
 import MissionInformation from './components/Overlay/MissionInformation';
 import OverlayWelcome from './components/Overlay/OverlayWelcome';
-import ResetProgressOverlay from './components/Overlay/ResetProgress';
 import useLocalStorage from './hooks/useLocalStorage';
 import { LEVEL_NAMES } from './models/level';
-import { resetService } from './service';
 
 import './App.css';
 import './Theme.css';
@@ -124,14 +122,6 @@ function App() {
 	function openDocumentViewer() {
 		openOverlay(<DocumentViewBox closeOverlay={closeOverlay} />);
 	}
-	function openResetProgressOverlay() {
-		openOverlay(
-			<ResetProgressOverlay
-				resetProgress={resetProgress}
-				closeOverlay={closeOverlay}
-			/>
-		);
-	}
 
 	// set the start level for a user who clicks beginner/expert
 	function setStartLevel(startLevel: LEVEL_NAMES) {
@@ -146,20 +136,6 @@ function App() {
 			setCurrentLevel(startLevel);
 		}
 		closeOverlay();
-	}
-
-	// resets whole game progress and start from level 1 or Sandbox
-	async function resetProgress() {
-		console.log('resetting progress for all levels');
-		await resetService.resetAllLevelProgress(); //yeeeeeeeee
-		resetCompletedLevels();
-
-		// set as new user so welcome modal shows
-		setIsNewUser(true);
-
-		// take the user to level 1 if on levels, or stay in sandbox
-		currentLevel !== LEVEL_NAMES.SANDBOX &&
-			setCurrentLevel(LEVEL_NAMES.LEVEL_1);
 	}
 
 	function goToSandbox() {
@@ -184,9 +160,10 @@ function App() {
 				openOverlay={openOverlay}
 				openInformationOverlay={openInformationOverlay}
 				openLevelsCompleteOverlay={openLevelsCompleteOverlay}
-				openResetProgressOverlay={openResetProgressOverlay}
 				openWelcomeOverlay={openWelcomeOverlay}
 				setCurrentLevel={setCurrentLevel}
+				resetCompletedLevels={resetCompletedLevels}
+				setIsNewUser={setIsNewUser}
 			/>
 		</div>
 	);

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -322,8 +322,17 @@ function MainComponent({
 	// resets whole game progress and start from level 1 or Sandbox
 	async function resetProgress() {
 		console.log('resetting progress for all levels');
-		await resetService.resetAllLevelProgress(); //yeeeeeeeee
 		resetCompletedLevels();
+
+		const { emails, chatHistory, defences, chatModel } =
+			await resetService.resetAllLevelProgress(currentLevel);
+		processBackendLevelData(
+			currentLevel,
+			emails,
+			chatHistory,
+			defences,
+			chatModel
+		);
 
 		// set as new user so welcome modal shows
 		setIsNewUser(true);

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -324,7 +324,7 @@ function MainComponent({
 		console.log('resetting progress for all levels');
 		resetCompletedLevels();
 
-		const resetServiceResult = await resetService.resetAllLevelProgress(
+		const resetServiceResult = await resetService.resetAllProgress(
 			currentLevel
 		);
 

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -323,8 +323,6 @@ function MainComponent({
 	async function resetProgress() {
 		console.log('resetting progress for all levels');
 		resetCompletedLevels();
-		// set as new user so welcome modal shows
-		setIsNewUser(true);
 
 		const resetServiceResult = await resetService.resetAllLevelProgress(
 			currentLevel
@@ -346,6 +344,9 @@ function MainComponent({
 			// game state will be updated by the [currentLevel] useEffect
 			setCurrentLevel(LEVEL_NAMES.LEVEL_1);
 		}
+
+		// set as new user so welcome modal shows
+		setIsNewUser(true);
 	}
 
 	function openResetProgressOverlay() {

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -328,6 +328,9 @@ function MainComponent({
 			currentLevel
 		);
 
+		// set as new user so welcome modal shows
+		setIsNewUser(true);
+
 		if (
 			currentLevel === LEVEL_NAMES.SANDBOX ||
 			currentLevel === LEVEL_NAMES.LEVEL_1
@@ -344,9 +347,6 @@ function MainComponent({
 			// game state will be updated by the [currentLevel] useEffect
 			setCurrentLevel(LEVEL_NAMES.LEVEL_1);
 		}
-
-		// set as new user so welcome modal shows
-		setIsNewUser(true);
 	}
 
 	function openResetProgressOverlay() {

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_DEFENCES } from '@src/Defences';
 import HandbookOverlay from '@src/components/HandbookOverlay/HandbookOverlay';
 import LevelMissionInfoBanner from '@src/components/LevelMissionInfoBanner/LevelMissionInfoBanner';
 import ResetLevelOverlay from '@src/components/Overlay/ResetLevel';
+import ResetProgressOverlay from '@src/components/Overlay/ResetProgress';
 import { ChatMessage, ChatModel } from '@src/models/chat';
 import {
 	DEFENCE_ID,
@@ -18,6 +19,7 @@ import {
 	defenceService,
 	emailService,
 	levelService,
+	resetService,
 	startService,
 } from '@src/service';
 
@@ -36,9 +38,10 @@ function MainComponent({
 	openInformationOverlay,
 	openLevelsCompleteOverlay,
 	openOverlay,
-	openResetProgressOverlay,
 	openWelcomeOverlay,
 	setCurrentLevel,
+	resetCompletedLevels,
+	setIsNewUser,
 }: {
 	currentLevel: LEVEL_NAMES;
 	numCompletedLevels: number;
@@ -48,9 +51,10 @@ function MainComponent({
 	openInformationOverlay: () => void;
 	openLevelsCompleteOverlay: () => void;
 	openOverlay: (overlayComponent: JSX.Element) => void;
-	openResetProgressOverlay: () => void;
 	openWelcomeOverlay: () => void;
 	setCurrentLevel: (newLevel: LEVEL_NAMES) => void;
+	resetCompletedLevels: () => void;
+	setIsNewUser: (isNewUser: boolean) => void;
 }) {
 	const [MainBodyKey, setMainBodyKey] = useState<number>(0);
 	const [defences, setDefences] = useState<Defence[]>(DEFAULT_DEFENCES);
@@ -313,6 +317,29 @@ function MainComponent({
 			return;
 		}
 		setChatModel({ ...chatModel, id: modelId });
+	}
+
+	// resets whole game progress and start from level 1 or Sandbox
+	async function resetProgress() {
+		console.log('resetting progress for all levels');
+		await resetService.resetAllLevelProgress(); //yeeeeeeeee
+		resetCompletedLevels();
+
+		// set as new user so welcome modal shows
+		setIsNewUser(true);
+
+		// take the user to level 1 if on levels, or stay in sandbox
+		currentLevel !== LEVEL_NAMES.SANDBOX &&
+			setCurrentLevel(LEVEL_NAMES.LEVEL_1);
+	}
+
+	function openResetProgressOverlay() {
+		openOverlay(
+			<ResetProgressOverlay
+				resetProgress={resetProgress}
+				closeOverlay={closeOverlay}
+			/>
+		);
 	}
 
 	return (

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -323,23 +323,29 @@ function MainComponent({
 	async function resetProgress() {
 		console.log('resetting progress for all levels');
 		resetCompletedLevels();
-
-		const { emails, chatHistory, defences, chatModel } =
-			await resetService.resetAllLevelProgress(currentLevel);
-		processBackendLevelData(
-			currentLevel,
-			emails,
-			chatHistory,
-			defences,
-			chatModel
-		);
-
 		// set as new user so welcome modal shows
 		setIsNewUser(true);
 
-		// take the user to level 1 if on levels, or stay in sandbox
-		currentLevel !== LEVEL_NAMES.SANDBOX &&
+		const resetServiceResult = await resetService.resetAllLevelProgress(
+			currentLevel
+		);
+
+		if (
+			currentLevel === LEVEL_NAMES.SANDBOX ||
+			currentLevel === LEVEL_NAMES.LEVEL_1
+		) {
+			const { emails, chatHistory, defences, chatModel } = resetServiceResult;
+			processBackendLevelData(
+				currentLevel,
+				emails,
+				chatHistory,
+				defences,
+				chatModel
+			);
+		} else {
+			// game state will be updated by the [currentLevel] useEffect
 			setCurrentLevel(LEVEL_NAMES.LEVEL_1);
+		}
 	}
 
 	function openResetProgressOverlay() {

--- a/frontend/src/service/resetService.ts
+++ b/frontend/src/service/resetService.ts
@@ -6,7 +6,7 @@ import { getDefencesFromDTOs } from './defenceService';
 
 const PATH = 'reset';
 
-async function resetAllLevelProgress(level: number) {
+async function resetAllProgress(level: number) {
 	const response = await sendRequest(`${PATH}?level=${level}`, {
 		method: 'POST',
 		headers: {
@@ -24,4 +24,4 @@ async function resetAllLevelProgress(level: number) {
 	};
 }
 
-export { resetAllLevelProgress };
+export { resetAllProgress };

--- a/frontend/src/service/resetService.ts
+++ b/frontend/src/service/resetService.ts
@@ -1,15 +1,27 @@
+import { LoadLevelResponse } from '@src/models/combined';
+
 import { sendRequest } from './backendService';
+import { getChatMessagesFromDTOResponse } from './chatService';
+import { getDefencesFromDTOs } from './defenceService';
 
 const PATH = 'reset';
 
-async function resetAllLevelProgress(): Promise<boolean> {
-	const response = await sendRequest(PATH, {
+async function resetAllLevelProgress(level: number) {
+	const response = await sendRequest(`${PATH}?level=${level}`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 		},
 	});
-	return response.status === 200;
+	const { defences, emails, chatHistory, chatModel } =
+		(await response.json()) as LoadLevelResponse;
+
+	return {
+		emails,
+		chatHistory: getChatMessagesFromDTOResponse(chatHistory),
+		defences: defences ? getDefencesFromDTOs(defences) : [],
+		chatModel,
+	};
 }
 
 export { resetAllLevelProgress };


### PR DESCRIPTION
## Description

Combines all network calls involved with resetting all progress into one network call.

## Screenshots

![image](https://github.com/ScottLogic/prompt-injection/assets/118171430/8b1120af-65f1-4f98-a4af-008fdceeaffa)
One network call when you reset all progress

## Notes

- We now pass the current level into the reset progress endpoint. The endpoint resets the values in the backend session storage and returns the state of the current level, which is then processed by the frontend to update the UI accordingly.
- I've update the endpoint to also reset the chat model configuration. Not in scope of ticket but I think it makes more sense then not resetting it, given all the defence configurations are reset.
- Updates the tests for levelController and startController to account for the changes made in #858, where we only return the chatModel on the sandbox.

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [x] Added tests
- [x] Ensured the workflow steps are passing
