### PR TITLE
Cleanup dialog opening/closing, remove click away to close behaviour

### DIFF
--- a/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
+++ b/frontend/src/components/DefenceBox/DefenceConfigurationRadioButton.css
@@ -1,8 +1,8 @@
 .defence-radio-button {
 	position: relative;
 	display: flex;
-	cursor: pointer;
 	gap: 0.75rem;
+	cursor: pointer;
 }
 
 .defence-radio-button input {

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -319,23 +319,17 @@ function MainComponent({
 		setChatModel({ ...chatModel, id: modelId });
 	}
 
-	// resets whole game progress and start from level 1 or Sandbox
+	// reset whole game progress and start from level 1 or Sandbox
 	async function resetProgress() {
-		console.log('resetting progress for all levels');
+		const levelState = await resetService.resetAllProgress(currentLevel);
 		resetCompletedLevels();
-
-		const resetServiceResult = await resetService.resetAllProgress(
-			currentLevel
-		);
-
-		// set as new user so welcome modal shows
-		setIsNewUser(true);
 
 		if (
 			currentLevel === LEVEL_NAMES.SANDBOX ||
 			currentLevel === LEVEL_NAMES.LEVEL_1
 		) {
-			const { emails, chatHistory, defences, chatModel } = resetServiceResult;
+			// staying on current level, so just update our state
+			const { emails, chatHistory, defences, chatModel } = levelState;
 			processBackendLevelData(
 				currentLevel,
 				emails,
@@ -344,9 +338,12 @@ function MainComponent({
 				chatModel
 			);
 		} else {
-			// game state will be updated by the [currentLevel] useEffect
+			// new state will be fetched as a result of level change
 			setCurrentLevel(LEVEL_NAMES.LEVEL_1);
 		}
+
+		// setting as new user causes welcome dialog to open
+		setIsNewUser(true);
 	}
 
 	function openResetProgressOverlay() {


### PR DESCRIPTION
## Description

There were a couple of timing-related bugs in the code, mostly due to HTMLDialogElement throwing an error if you try to open a dialog when it's already open. This was happening due to some convoluted logic in the sequence of events from Reset All Progress dialog to Welcome dialog to Mission Info dialog, including some useEffect side-effects on component update. I've simplified the logic, but also needed to remove the "click away to close dialog" behaviour, because it was causing an unrecoverable problem in which more than one click handler could become bound to the window, causing some dialogs to close as soon as they'd opened.

Resolves #862 

## Notes

- "Click away to close" behaviour has been removed
- "Escape to close" behaviour unchanged
- Tested as thoroughly as I can!

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
