### PR TITLE
712 Show error when unable to get document to view

### DIFF
--- a/frontend/src/components/DocumentViewer/DocumentViewBox.css
+++ b/frontend/src/components/DocumentViewer/DocumentViewBox.css
@@ -38,6 +38,7 @@
 	border: 0.1875rem solid var(--main-border-colour);
 	background: var(--main-background);
 	aspect-ratio: 7/8;
+	color: var(--main-text-colour);
 }
 
 .document-viewer-container {

--- a/frontend/src/components/DocumentViewer/DocumentViewBox.test.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentViewBox.test.tsx
@@ -261,4 +261,21 @@ describe('DocumentViewBox component tests', () => {
 			expect(nextButton).toBeEnabled();
 		});
 	});
+
+	describe('With zero documents', () => {
+		const documents = [] as MockDocument[];
+
+		beforeEach(() => {
+			setupMocks(documents);
+		});
+
+		test('GIVEN are zero documents THEN an error message is shown', async () => {
+			const ExpectedErrorText =
+				'Unable to fetch documents. Try again in a few minutes.';
+			renderDocumentViewBox();
+			const messageElement = await screen.findByText(ExpectedErrorText);
+
+			expect(messageElement).toBeInTheDocument();
+		});
+	});
 });

--- a/frontend/src/components/DocumentViewer/DocumentViewBox.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentViewBox.tsx
@@ -39,37 +39,44 @@ function DocumentViewBox({ closeOverlay }: { closeOverlay: () => void }) {
 				iconColor="#FFF"
 			/>
 			<div className="view-documents-main">
-				<DocumentViewBoxNav
-					documentIndex={documentIndex}
-					documentName={documentMetas[documentIndex]?.filename ?? ''}
-					numberOfDocuments={documentMetas.length}
-					onPrevious={() => {
-						if (documentIndex > 0) {
-							setDocumentIndex(documentIndex - 1);
-						}
-					}}
-					onNext={() => {
-						if (documentIndex < documentMetas.length - 1) {
-							setDocumentIndex(documentIndex + 1);
-						}
-					}}
-				/>
-				<div
-					className="document-viewer-container"
-					// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-					tabIndex={0}
-				>
-					<DocViewer
-						documents={documentMetas}
-						activeDocument={documentMetas[documentIndex]}
-						pluginRenderers={DocViewerRenderers}
-						config={{
-							header: {
-								disableHeader: true,
-							},
-						}}
-					/>
-				</div>
+				{documentMetas.length > 0 ? (
+					<>
+						<DocumentViewBoxNav
+							documentIndex={documentIndex}
+							documentName={documentMetas[documentIndex]?.filename ?? ''}
+							numberOfDocuments={documentMetas.length}
+							onPrevious={() => {
+								if (documentIndex > 0) {
+									setDocumentIndex(documentIndex - 1);
+								}
+							}}
+							onNext={() => {
+								if (documentIndex < documentMetas.length - 1) {
+									setDocumentIndex(documentIndex + 1);
+								}
+							}}
+						/>
+
+						<div
+							className="document-viewer-container"
+							// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+							tabIndex={0}
+						>
+							<DocViewer
+								documents={documentMetas}
+								activeDocument={documentMetas[documentIndex]}
+								pluginRenderers={DocViewerRenderers}
+								config={{
+									header: {
+										disableHeader: true,
+									},
+								}}
+							/>
+						</div>
+					</>
+				) : (
+					<p>Unable to fetch documents. Try again in a few minutes.</p>
+				)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Description

A `DocumentMeta` is a set of information about a retrieval document in the backend (e.g, uri, filename, type etc). We retrieve a list of `documentMeta`s when the `DocumentViewBox` component mounts. If we fail to retrieve these from the backend, then we show an error message.

## Screenshots

![image](https://github.com/ScottLogic/prompt-injection/assets/118171430/f700dc38-c03d-40f5-b7db-003fa19b9a33)

## Concerns

- This won't help us if the backend stops responding in between retrieving the `documentMeta`s and attempting to retrieve an individual document, but there's not a lot we can do about that given the library component.

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [x] Added tests
- [x] Ensured the workflow steps are passing
