### PR TITLE
828 streamline configure defence info message network call

### DIFF
--- a/backend/src/controller/defenceController.ts
+++ b/backend/src/controller/defenceController.ts
@@ -9,8 +9,10 @@ import {
 import { DefenceActivateRequest } from '@src/models/api/DefenceActivateRequest';
 import { DefenceConfigItemResetRequest } from '@src/models/api/DefenceConfigResetRequest';
 import { DefenceConfigureRequest } from '@src/models/api/DefenceConfigureRequest';
+import { ChatInfoMessage } from '@src/models/chatMessage';
 import { DefenceConfigItem } from '@src/models/defence';
 import { LEVEL_NAMES, isValidLevel } from '@src/models/level';
+import { pushMessageToHistory } from '@src/utils/chat';
 
 import { sendErrorResponse } from './handleError';
 
@@ -144,7 +146,21 @@ function handleConfigureDefence(req: DefenceConfigureRequest, res: Response) {
 		currentDefences,
 		config
 	);
-	res.send();
+
+	const displayedDefenceId = defenceId.replace(/_/g, ' ').toLowerCase();
+	const resultingChatInfoMessage = {
+		infoMessage: `${displayedDefenceId} defence updated`,
+		chatMessageType: 'GENERIC_INFO',
+	} as ChatInfoMessage;
+
+	req.session.levelState[level].chatHistory = pushMessageToHistory(
+		req.session.levelState[level].chatHistory,
+		resultingChatInfoMessage
+	);
+
+	res.send({
+		resultingChatInfoMessage,
+	});
 }
 
 function handleResetDefenceConfigItem(

--- a/backend/src/controller/defenceController.ts
+++ b/backend/src/controller/defenceController.ts
@@ -148,18 +148,18 @@ function handleConfigureDefence(req: DefenceConfigureRequest, res: Response) {
 	);
 
 	const displayedDefenceId = defenceId.replace(/_/g, ' ').toLowerCase();
-	const resultingChatInfoMessage = {
+	const chatInfoMessage = {
 		infoMessage: `${displayedDefenceId} defence updated`,
 		chatMessageType: 'GENERIC_INFO',
 	} as ChatInfoMessage;
 
 	req.session.levelState[level].chatHistory = pushMessageToHistory(
 		req.session.levelState[level].chatHistory,
-		resultingChatInfoMessage
+		chatInfoMessage
 	);
 
 	res.send({
-		resultingChatInfoMessage,
+		chatInfoMessage,
 	});
 }
 

--- a/backend/src/models/api/DefenceConfigureRequest.ts
+++ b/backend/src/models/api/DefenceConfigureRequest.ts
@@ -8,7 +8,7 @@ export type DefenceConfigureRequest = Request<
 	never,
 	| string
 	| {
-			resultingChatInfoMessage: ChatInfoMessage;
+			chatInfoMessage: ChatInfoMessage;
 	  },
 	{
 		config?: DefenceConfigItem[];

--- a/backend/src/models/api/DefenceConfigureRequest.ts
+++ b/backend/src/models/api/DefenceConfigureRequest.ts
@@ -1,11 +1,15 @@
 import { Request } from 'express';
 
+import { ChatInfoMessage } from '@src/models/chatMessage';
 import { DEFENCE_ID, DefenceConfigItem } from '@src/models/defence';
 import { LEVEL_NAMES } from '@src/models/level';
 
 export type DefenceConfigureRequest = Request<
 	never,
-	null | string,
+	| string
+	| {
+			resultingChatInfoMessage: ChatInfoMessage;
+	  },
 	{
 		config?: DefenceConfigItem[];
 		defenceId?: DEFENCE_ID;

--- a/backend/test/unit/controller/defenceController.test.ts
+++ b/backend/test/unit/controller/defenceController.test.ts
@@ -437,16 +437,16 @@ describe('handleConfigureDefence', () => {
 			configuredDefences
 		);
 
-		const expectedResultingChatMessage = {
+		const expectedChatInfoMessage = {
 			infoMessage: 'prompt evaluation llm defence updated',
 			chatMessageType: 'GENERIC_INFO',
 		} as ChatInfoMessage;
 		expect(
 			req.session.levelState[LEVEL_NAMES.SANDBOX].chatHistory.at(-1)
-		).toEqual(expectedResultingChatMessage);
+		).toEqual(expectedChatInfoMessage);
 
 		expect(res.send).toHaveBeenCalledWith({
-			resultingChatInfoMessage: expectedResultingChatMessage,
+			chatInfoMessage: expectedChatInfoMessage,
 		});
 	});
 

--- a/backend/test/unit/controller/defenceController.test.ts
+++ b/backend/test/unit/controller/defenceController.test.ts
@@ -16,7 +16,7 @@ import {
 import { DefenceActivateRequest } from '@src/models/api/DefenceActivateRequest';
 import { DefenceConfigItemResetRequest } from '@src/models/api/DefenceConfigResetRequest';
 import { DefenceConfigureRequest } from '@src/models/api/DefenceConfigureRequest';
-import { ChatMessage } from '@src/models/chatMessage';
+import { ChatInfoMessage, ChatMessage } from '@src/models/chatMessage';
 import {
 	DEFENCE_CONFIG_ITEM_ID,
 	DEFENCE_ID,
@@ -365,7 +365,7 @@ describe('handleDefenceDeactivation', () => {
 });
 
 describe('handleConfigureDefence', () => {
-	test('WHEN passed a sensible config value THEN configures defence', () => {
+	test('WHEN passed a sensible config value THEN configures defence AND adds info message to history AND responds with info message', () => {
 		const mockConfigureDefence = configureDefence as jest.MockedFunction<
 			typeof configureDefence
 		>;
@@ -402,6 +402,8 @@ describe('handleConfigureDefence', () => {
 			},
 		} as DefenceConfigureRequest;
 
+		const res = responseMock();
+
 		const configuredDefences: Defence[] = [
 			{
 				id: 'PROMPT_EVALUATION_LLM',
@@ -412,7 +414,7 @@ describe('handleConfigureDefence', () => {
 		];
 		mockConfigureDefence.mockReturnValueOnce(configuredDefences);
 
-		handleConfigureDefence(req, responseMock());
+		handleConfigureDefence(req, res);
 
 		expect(mockConfigureDefence).toHaveBeenCalledTimes(1);
 		expect(mockConfigureDefence).toHaveBeenCalledWith(
@@ -434,6 +436,18 @@ describe('handleConfigureDefence', () => {
 		expect(req.session.levelState[LEVEL_NAMES.SANDBOX].defences).toEqual(
 			configuredDefences
 		);
+
+		const expectedResultingChatMessage = {
+			infoMessage: 'prompt evaluation llm defence updated',
+			chatMessageType: 'GENERIC_INFO',
+		} as ChatInfoMessage;
+		expect(
+			req.session.levelState[LEVEL_NAMES.SANDBOX].chatHistory.at(-1)
+		).toEqual(expectedResultingChatMessage);
+
+		expect(res.send).toHaveBeenCalledWith({
+			resultingChatInfoMessage: expectedResultingChatMessage,
+		});
 	});
 
 	test('WHEN missing defenceId THEN does not configure defence', () => {

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -261,13 +261,13 @@ function MainComponent({
 		defenceId: DEFENCE_ID,
 		config: DefenceConfigItem[]
 	) {
-		const success = await defenceService.configureDefence(
+		const resultingChatInfoMessage = await defenceService.configureDefence(
 			defenceId,
 			config,
 			currentLevel
 		);
-		if (success) {
-			addConfigUpdateToChat(defenceId, 'updated');
+		if (resultingChatInfoMessage) {
+			addChatMessage(resultingChatInfoMessage);
 			// update state
 			const newDefences = defences.map((defence) => {
 				if (defence.id === defenceId) {
@@ -277,7 +277,7 @@ function MainComponent({
 			});
 			setDefences(newDefences);
 		}
-		return success;
+		return resultingChatInfoMessage !== null;
 	}
 
 	function setMessagesWithWelcome(retrievedMessages: ChatMessage[]) {

--- a/frontend/src/models/combined.ts
+++ b/frontend/src/models/combined.ts
@@ -19,4 +19,8 @@ type LoadLevelResponse = {
 	chatModel?: ChatModel;
 };
 
-export type { StartReponse, LoadLevelResponse };
+type ConfigureDefenceResponse = {
+	resultingChatInfoMessage: ChatMessageDTO;
+};
+
+export type { StartReponse, LoadLevelResponse, ConfigureDefenceResponse };

--- a/frontend/src/models/combined.ts
+++ b/frontend/src/models/combined.ts
@@ -20,7 +20,7 @@ type LoadLevelResponse = {
 };
 
 type ConfigureDefenceResponse = {
-	resultingChatInfoMessage: ChatMessageDTO;
+	chatInfoMessage: ChatMessageDTO;
 };
 
 export type { StartReponse, LoadLevelResponse, ConfigureDefenceResponse };

--- a/frontend/src/service/chatService.ts
+++ b/frontend/src/service/chatService.ts
@@ -110,4 +110,5 @@ export {
 	setGptModel,
 	addInfoMessageToChatHistory,
 	getChatMessagesFromDTOResponse,
+	makeChatMessageFromDTO,
 };

--- a/frontend/src/service/defenceService.ts
+++ b/frontend/src/service/defenceService.ts
@@ -66,12 +66,12 @@ async function configureDefence(
 		body: JSON.stringify({ defenceId, config, level }),
 	});
 
-	const { resultingChatInfoMessage } =
+	if (response.status !== 200) return null;
+
+	const { chatInfoMessage } =
 		(await response.json()) as ConfigureDefenceResponse;
 
-	return response.status === 200
-		? makeChatMessageFromDTO(resultingChatInfoMessage)
-		: null;
+	return makeChatMessageFromDTO(chatInfoMessage);
 }
 
 async function resetDefenceConfigItem(

--- a/frontend/src/service/defenceService.ts
+++ b/frontend/src/service/defenceService.ts
@@ -1,4 +1,6 @@
 import { DEFAULT_DEFENCES } from '@src/Defences';
+import { ChatMessage } from '@src/models/chat';
+import { ConfigureDefenceResponse } from '@src/models/combined';
 import {
 	DEFENCE_ID,
 	DefenceConfigItem,
@@ -9,6 +11,7 @@ import {
 import { LEVEL_NAMES } from '@src/models/level';
 
 import { sendRequest } from './backendService';
+import { makeChatMessageFromDTO } from './chatService';
 
 const PATH = 'defence/';
 
@@ -54,7 +57,7 @@ async function configureDefence(
 	defenceId: DEFENCE_ID,
 	config: DefenceConfigItem[],
 	level: LEVEL_NAMES
-): Promise<boolean> {
+): Promise<ChatMessage | null> {
 	const response = await sendRequest(`${PATH}configure`, {
 		method: 'POST',
 		headers: {
@@ -62,7 +65,13 @@ async function configureDefence(
 		},
 		body: JSON.stringify({ defenceId, config, level }),
 	});
-	return response.status === 200;
+
+	const { resultingChatInfoMessage } =
+		(await response.json()) as ConfigureDefenceResponse;
+
+	return response.status === 200
+		? makeChatMessageFromDTO(resultingChatInfoMessage)
+		: null;
 }
 
 async function resetDefenceConfigItem(


### PR DESCRIPTION
⚠ Note, don't believe the branch name!

## Description

Before, when the user would configure a defence, we would send a request to the backend. If the backend successfully configured the defence, then the frontend would send a further request to add the info message to the chat history, eg 'character limit defence updated'.

This PR changes it so that when the backend successfully configures a defence, the backend generates the info message and appends it to the history, then forwards it on to the frontend.

## Concerns

- similar to #872 I'm not certain we want to be wrapping the resultingChatInfoMessage in the response object just so that we can name it.

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [x] Added tests
- [x] Ensured the workflow steps are passing
