### PR TITLE
Correct flash of wrong level after Getting Started

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -104,8 +104,13 @@ function App() {
 
 	// set the start level for a user who clicks beginner/expert
 	function setStartLevel(startLevel: LEVEL_NAMES) {
-		setCurrentLevel(startLevel);
-		openInformationOverlay();
+		if (currentLevel !== startLevel) {
+			// Changing level triggers info overlay: wait for that to avoid flash-of-wrong-level
+			setCurrentLevel(startLevel);
+		} else {
+			// Same level will not trigger info overlay, so must open manually
+			openInformationOverlay();
+		}
 	}
 
 	return (


### PR DESCRIPTION
## Description

There is an issue since #866 was merged, where we see a flash of wrong level when switching between Sandbox and Level 1 from the Getting Started dialog. It's a really brief flash but enough to cause some unease. Hopefully this fixes the problem, though I need another, sharper set of eyes on it! 🤓 

Closes #862 

## Notes

- There is a useEffect that brings up the MissionInfo dialog whenever the level changes. This was being triggered _after update_ as expected, but additionally we were opening the dialog manually, which was happening in the first update cycle before the level change took effect.

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
