### PR TITLE
Mode Selection Buttons updated

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,7 +72,6 @@ function App() {
 		setIsNewUser(false);
 		openOverlay(
 			<OverlayWelcome
-				currentLevel={currentLevel}
 				setStartLevel={(level: LEVEL_NAMES) => {
 					setStartLevel(level);
 				}}

--- a/frontend/src/components/DocumentViewer/DocumentViewBox.css
+++ b/frontend/src/components/DocumentViewer/DocumentViewBox.css
@@ -37,8 +37,8 @@
 	padding: 2rem;
 	border: 0.1875rem solid var(--main-border-colour);
 	background: var(--main-background);
-	aspect-ratio: 7/8;
 	color: var(--main-text-colour);
+	aspect-ratio: 7/8;
 }
 
 .document-viewer-container {

--- a/frontend/src/components/LevelSelectionBox/LevelSelectionBox.tsx
+++ b/frontend/src/components/LevelSelectionBox/LevelSelectionBox.tsx
@@ -29,7 +29,7 @@ function LevelSelectionBox({
 	}
 
 	return (
-		<div className="level-selection-box">
+		<nav className="level-selection-box">
 			{displayLevels.map(({ id, displayName }, index) => {
 				const disabled =
 					index > numCompletedLevels && id !== LEVEL_NAMES.SANDBOX;
@@ -62,7 +62,7 @@ function LevelSelectionBox({
 					</ThemedButton>
 				);
 			})}
-		</div>
+		</nav>
 	);
 }
 

--- a/frontend/src/components/Overlay/OverlayWelcome.tsx
+++ b/frontend/src/components/Overlay/OverlayWelcome.tsx
@@ -5,11 +5,9 @@ import { LEVEL_NAMES } from '@src/models/level';
 import MultipageOverlay from './MultipageOverlay';
 
 function OverlayWelcome({
-	currentLevel,
 	setStartLevel,
 	closeOverlay,
 }: {
-	currentLevel: LEVEL_NAMES;
 	setStartLevel: (newLevel: LEVEL_NAMES) => void;
 	closeOverlay: () => void;
 }) {
@@ -43,10 +41,7 @@ function OverlayWelcome({
 						beginning, or are you an expert spy, and would prefer to jump
 						straight in at the sandbox?
 					</p>
-					<StartLevelButtons
-						currentLevel={currentLevel}
-						setStartLevel={setStartLevel}
-					/>
+					<StartLevelButtons setStartLevel={setStartLevel} />
 				</>
 			),
 			imageUrl: BotAvatarDefault,

--- a/frontend/src/components/ThemedButtons/ChatButton.css
+++ b/frontend/src/components/ThemedButtons/ChatButton.css
@@ -2,6 +2,7 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	width: 100%;
 	padding: 0.75rem;
 	border: 1px solid var(--chat-button-border-colour);
 	border-radius: 0.625rem;
@@ -9,7 +10,6 @@
 	color: var(--chat-button-text-colour);
 	font-weight: 700;
 	font-size: 1rem;
-	width: 100%;
 }
 
 .chat-button:hover {

--- a/frontend/src/components/ThemedButtons/LevelsCompleteButtons.tsx
+++ b/frontend/src/components/ThemedButtons/LevelsCompleteButtons.tsx
@@ -24,13 +24,7 @@ function LevelsCompleteButtons({
 		}
 	}
 
-	return (
-		<ModeSelectButtons
-			defaultSelection={lastLevel}
-			modeButtons={modes}
-			setLevel={handleLevelSelect}
-		/>
-	);
+	return <ModeSelectButtons modeButtons={modes} setLevel={handleLevelSelect} />;
 }
 
 export default LevelsCompleteButtons;

--- a/frontend/src/components/ThemedButtons/ModeSelectButtons.css
+++ b/frontend/src/components/ThemedButtons/ModeSelectButtons.css
@@ -12,7 +12,7 @@
 	align-items: center;
 	margin: 0;
 	padding: 1rem 2rem;
-	border: 0.0625rem solid var(--overlay-tab-colour);
+	border: 0.125rem solid var(--overlay-tab-colour);
 	border-radius: 0.5rem;
 	background-color: var(--overlay-background-colour);
 	font-weight: 700;
@@ -20,10 +20,6 @@
 	line-height: 1;
 	white-space: nowrap;
 	transition: ease 0.1s;
-}
-
-.mode-selection-buttons .mode-button.selected {
-	background-color: var(--overlay-tab-colour);
 }
 
 .mode-selection-buttons button:hover {

--- a/frontend/src/components/ThemedButtons/ModeSelectButtons.tsx
+++ b/frontend/src/components/ThemedButtons/ModeSelectButtons.tsx
@@ -12,11 +12,9 @@ function ModeSelectButtons({
 	return (
 		<ul className="mode-selection-buttons">
 			{modeButtons.map((modeButton) => (
-				<li
-					key={modeButton.targetLevel}
-				>
+				<li key={modeButton.targetLevel}>
 					<button
-						className='mode-button'
+						className="mode-button"
 						onClick={() => {
 							setLevel(modeButton.targetLevel);
 						}}

--- a/frontend/src/components/ThemedButtons/ModeSelectButtons.tsx
+++ b/frontend/src/components/ThemedButtons/ModeSelectButtons.tsx
@@ -1,35 +1,22 @@
-import { clsx } from 'clsx';
-
 import { LEVEL_NAMES, ModeSelectButton } from '@src/models/level';
 
 import './ModeSelectButtons.css';
 
 function ModeSelectButtons({
-	defaultSelection,
 	modeButtons,
 	setLevel,
 }: {
-	defaultSelection: LEVEL_NAMES;
 	modeButtons: ModeSelectButton[];
 	setLevel: (newLevel: LEVEL_NAMES) => void;
 }) {
-	function defaultButton(targetLevel: LEVEL_NAMES) {
-		return targetLevel === defaultSelection;
-	}
-
 	return (
 		<ul className="mode-selection-buttons">
 			{modeButtons.map((modeButton) => (
 				<li
 					key={modeButton.targetLevel}
-					aria-current={
-						defaultButton(modeButton.targetLevel) ? 'page' : undefined
-					}
 				>
 					<button
-						className={clsx('mode-button', {
-							selected: defaultButton(modeButton.targetLevel),
-						})}
+						className='mode-button'
 						onClick={() => {
 							setLevel(modeButton.targetLevel);
 						}}

--- a/frontend/src/components/ThemedButtons/StartLevelButtons.tsx
+++ b/frontend/src/components/ThemedButtons/StartLevelButtons.tsx
@@ -3,10 +3,8 @@ import { LEVEL_NAMES, ModeSelectButton } from '@src/models/level';
 import ModeSelectButtons from './ModeSelectButtons';
 
 function StartLevelButtons({
-	currentLevel,
 	setStartLevel,
 }: {
-	currentLevel: LEVEL_NAMES;
 	setStartLevel: (newLevel: LEVEL_NAMES) => void;
 }) {
 	const levels: ModeSelectButton[] = [
@@ -14,13 +12,7 @@ function StartLevelButtons({
 		{ displayName: 'Sandbox', targetLevel: LEVEL_NAMES.SANDBOX },
 	];
 
-	return (
-		<ModeSelectButtons
-			defaultSelection={currentLevel}
-			modeButtons={levels}
-			setLevel={setStartLevel}
-		/>
-	);
+	return <ModeSelectButtons modeButtons={levels} setLevel={setStartLevel} />;
 }
 
 export default StartLevelButtons;

--- a/frontend/src/components/ThemedButtons/ThemedButton.css
+++ b/frontend/src/components/ThemedButtons/ThemedButton.css
@@ -54,10 +54,10 @@
 }
 
 .themed-button-tooltip.show.bottom-center {
-	right: 50%;
-	transform: translateX(50%);
-	bottom: calc(100% + 0.125rem);
 	top: auto;
+	right: 50%;
+	bottom: calc(100% + 0.125rem);
+	transform: translateX(50%);
 }
 
 .themed-button:hover + .themed-button-tooltip.show,


### PR DESCRIPTION
# Description
When you select between two levels (Level 1 vs Sandbox or Level 3 vs Sandbox), the button for the level that you are currently on is differently styled to the one that you are not on. This is not very clear, so now we want the two buttons to just look the same.

Also added on a tiny `<div>` to `<nav>` change onto this PR as discussed

## Acceptance criteria
GIVEN a user is on a modal that lets you switch between two levels (Getting started & Congratulations)
WHEN they look at the two level button options
THEN they look the same

**Additional**: Level 1 2 3 Sandbox still behave as they did before but are now in a `nav` container element.  

## Screenshot before
![Image](https://github.com/ScottLogic/prompt-injection/assets/125262707/9b50344e-ea87-469d-87c4-702f90ca7fc9)

## Screenshot expected outcome
![Image](https://github.com/ScottLogic/prompt-injection/assets/125262707/e41f154c-4a3c-48d8-a74a-936b0309064a)


## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] Added tests
- [x] Ensured the workflow steps are passing
