### PR TITLE
Use all vectorstore documents in QA LLM context

### DIFF
--- a/backend/src/document.ts
+++ b/backend/src/document.ts
@@ -1,7 +1,9 @@
 import { OpenAIEmbeddings } from '@langchain/openai';
 import { CSVLoader } from 'langchain/document_loaders/fs/csv';
-import { DirectoryLoader } from 'langchain/document_loaders/fs/directory';
-import { PDFLoader } from 'langchain/document_loaders/fs/pdf';
+import {
+	DirectoryLoader,
+	UnknownHandling,
+} from 'langchain/document_loaders/fs/directory';
 import { TextLoader } from 'langchain/document_loaders/fs/text';
 import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
 import { MemoryVectorStore } from 'langchain/vectorstores/memory';
@@ -14,25 +16,20 @@ import { LEVEL_NAMES } from './models/level';
 async function getDocuments(filePath: string) {
 	console.debug(`Loading documents from: ${filePath}`);
 
-	const loader: DirectoryLoader = new DirectoryLoader(filePath, {
-		'.pdf': (path: string) => new PDFLoader(path),
-		'.txt': (path: string) => new TextLoader(path),
-		'.csv': (path: string) => new CSVLoader(path),
-	});
+	const loader: DirectoryLoader = new DirectoryLoader(
+		filePath,
+		{
+			'.txt': (path: string) => new TextLoader(path),
+			// CSV loader returns one document per row
+			'.csv': (path: string) => new CSVLoader(path),
+		},
+		true,
+		UnknownHandling.Warn
+	);
 	const docs = await loader.load();
 	console.debug(`${docs.length} documents found`);
 
-	// split the documents into chunks
-	const textSplitter = new RecursiveCharacterTextSplitter({
-		chunkSize: 1000,
-		chunkOverlap: 0,
-	});
-
-	// need to disable the linting rule here
-	// as it's possible for the splitDocuments method to return undefined
-	// despite what the return type says
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-	return (await textSplitter.splitDocuments(docs)) ?? [];
+	return new RecursiveCharacterTextSplitter().splitDocuments(docs);
 }
 
 function getFilepath(target: LEVEL_NAMES | 'common') {

--- a/backend/src/langchain.ts
+++ b/backend/src/langchain.ts
@@ -50,9 +50,11 @@ function initQAModel(level: LEVEL_NAMES, Prompt: string) {
 		'QA prompt template'
 	);
 	console.debug(`QA chain initialised with model: ${modelName}`);
-	return RetrievalQAChain.fromLLM(model, documentVectors.asRetriever(), {
-		prompt: promptTemplate,
-	});
+	return RetrievalQAChain.fromLLM(
+		model,
+		documentVectors.asRetriever(documentVectors.memoryVectors.length),
+		{ prompt: promptTemplate }
+	);
 }
 
 function initPromptEvaluationModel(configPromptEvaluationPrompt: string) {

--- a/backend/src/openai.ts
+++ b/backend/src/openai.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'node:util';
 import { OpenAI } from 'openai';
 import {
 	ChatCompletionMessageParam,
@@ -256,7 +257,7 @@ async function chatGptChatCompletion(
 		});
 		console.debug(
 			'chat_completion=',
-			chat_completion.choices[0].message,
+			inspect(chat_completion.choices[0].message, { depth: 4 }),
 			' tokens=',
 			chat_completion.usage
 		);

--- a/backend/test/unit/document.ts/initDocumentVectors.test.ts
+++ b/backend/test/unit/document.ts/initDocumentVectors.test.ts
@@ -15,6 +15,9 @@ jest.mock('langchain/document_loaders/fs/directory', () => {
 				load: mockLoader,
 			};
 		}),
+		UnknownHandling: {
+			Warn: 'warn',
+		},
 	};
 });
 
@@ -31,10 +34,12 @@ jest.mock('langchain/text_splitter', () => {
 
 beforeAll(() => {
 	mockLoader.mockResolvedValue([]);
+	mockSplitDocuments.mockResolvedValue([]);
 });
 
 afterEach(() => {
 	mockLoader.mockClear();
+	mockSplitDocuments.mockClear();
 });
 
 test('GIVEN application WHEN application starts THEN document vectors are loaded for all levels', async () => {

--- a/backend/test/unit/langchain.ts/initialiseQAModel.test.ts
+++ b/backend/test/unit/langchain.ts/initialiseQAModel.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, test, jest, expect } from '@jest/globals';
 import { PromptTemplate } from '@langchain/core/prompts';
 import { ChatOpenAI } from '@langchain/openai';
 import { RetrievalQAChain } from 'langchain/chains';
+import { MemoryVectorStore } from 'langchain/vectorstores/memory';
 
 import { getDocumentVectors } from '@src/document';
 import { queryDocuments } from '@src/langchain';
@@ -53,10 +54,20 @@ jest.mock('@src/openai', () => {
 
 jest.mock('@src/document');
 const mockGetDocumentVectors = getDocumentVectors as unknown as jest.Mock<
-	() => { docVector: { asRetriever: () => string } }[]
+	() => {
+		docVector: {
+			asRetriever: (k: number) => string;
+			memoryVectors: MemoryVectorStore['memoryVectors'];
+		};
+	}[]
 >;
 mockGetDocumentVectors.mockReturnValue([
-	{ docVector: { asRetriever: () => 'retriever' } },
+	{
+		docVector: {
+			asRetriever: () => 'retriever',
+			memoryVectors: [],
+		},
+	},
 ]);
 
 beforeEach(() => {


### PR DESCRIPTION
## Description

Found and squished a bug in our Q&A process: we were not passing all documents in chat context to the Q&A LLM, as the default documents to retrieve from is 4 and we were not overriding this. This caused an odd symptom in which the bot was seemingly unable to answer a question about employees or salaries in full - instead one needed to piece together a complete answer from several consecutive questions, and even then you'd not know you were in receipt of the complete answer unless you knew what you were looking for.

The fix is simple, though there are related test changes, plus an incorrect comment and lint-ignore statement were also tackled here.

#Resolves #902

## Screenshots

All salary info found in one call:

![image](https://github.com/ScottLogic/prompt-injection/assets/15246391/35ca75ad-63c9-4921-83ca-76f7713de5e2)

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [ ] ~Added tests~ Corrected existing tests
- [x] Ensured the workflow steps are passing
