### PR TITLE
Prepare for prod-stage deployments

### DIFF
--- a/cloud/bin/cloud.ts
+++ b/cloud/bin/cloud.ts
@@ -32,7 +32,7 @@ const tags = {
 
 /* Stack constructs */
 
-const hostedZoneStack = new HostedZoneStack(app, generateStackName('hosted-zone'), {
+const hostedZoneStack = new HostedZoneStack(app, generateStackName('hostedzone'), {
 	description: generateDescription('Hosted Zone stack'),
 	env,
 	tags,

--- a/cloud/lib/api-stack.ts
+++ b/cloud/lib/api-stack.ts
@@ -31,7 +31,7 @@ import { RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
 import { join } from 'node:path';
 
-import { appName, resourceId } from './resourceNamingUtils';
+import { appName, resourceId, stageName } from './resourceNamingUtils';
 
 type ApiStackProps = StackProps & {
 	apiDomainName: string;
@@ -46,6 +46,7 @@ export class ApiStack extends Stack {
 		super(scope, id, props);
 
 		const generateResourceId = resourceId(scope);
+		const stage = stageName(scope);
 
 		const {
 			apiDomainName,
@@ -76,7 +77,7 @@ export class ApiStack extends Stack {
 		const apiKeySecret = Secret.fromSecretNameV2(
 			this,
 			generateResourceId('apikey'),
-			'dev/SpyLogic/ApiKey'
+			`${stage}/SpyLogic/ApiKey`
 		);
 
 		/*

--- a/cloud/lib/hostedzone-stack.ts
+++ b/cloud/lib/hostedzone-stack.ts
@@ -19,7 +19,7 @@ export class HostedZoneStack extends Stack {
 			throw new Error('HOSTED_ZONE_ID not found in env vars');
 		}
 
-		this.hostedZone = HostedZone.fromHostedZoneAttributes(this, resourceId(scope)('hosted-zone'), {
+		this.hostedZone = HostedZone.fromHostedZoneAttributes(this, resourceId(scope)('hostedzone'), {
 			hostedZoneId: HOSTED_ZONE_ID,
 			zoneName: DOMAIN_NAME,
 		});

--- a/cloud/lib/ui-stack.ts
+++ b/cloud/lib/ui-stack.ts
@@ -23,7 +23,7 @@ import { Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
 import { join } from 'node:path';
 
-import { appName, resourceId } from './resourceNamingUtils';
+import { appName, resourceId, stackName } from './resourceNamingUtils';
 
 type UiStackProps = StackProps & {
 	apiDomainName: string;
@@ -94,6 +94,7 @@ export class UiStack extends Stack {
 			generateResourceId('api-gatekeeper'),
 			{
 				functionName: 'edge-api-gatekeeper',
+				stackId: stackName(scope)('edge-lambda'),
 				handler: 'index.handler',
 				runtime: Runtime.NODEJS_18_X,
 				code: new TypeScriptCode(join(__dirname, 'lambdas/verifyAuth/index.ts'), {

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -6,6 +6,7 @@
 	},
 	"scripts": {
 		"cdk:synth": "cdk synth -q \"*\"",
+		"cdk:synth:prod": "cdk synth --context STAGE=prod -q \"*\"",
 		"cdk:diff": "cdk diff --app cdk.out",
 		"cdk:deploy": "cdk deploy --app cdk.out",
 		"cdk:deploy:all": "cdk deploy --app cdk.out --all",


### PR DESCRIPTION
## Description

A few tweaks to the cloud infra to allow deploying to prod (or any other named) stage.

## Notes

- Infra was already setup to allow staged deployments, but I forgot about the name of the apiKey secret.
- Added a utility script to package.json, specifically for prod template synthesis

## Checklist

Have you done the following?

- [ ] ~Linked the relevant Issue~ (no issue, part of cloud infra feature)
- [ ] Added tests
- [ ] Ensured the workflow steps are passing
