### PR TITLE
912: Update available GPT models

### DIFF
--- a/backend/src/langchain.ts
+++ b/backend/src/langchain.ts
@@ -30,7 +30,14 @@ function makePromptTemplate(
 }
 
 function getChatModel(): CHAT_MODEL_ID {
-	return getValidOpenAIModels().includes('gpt-4') ? 'gpt-4' : 'gpt-3.5-turbo';
+	const validModels = getValidOpenAIModels();
+	// GPT-4 is the most expensive model by a long way, avoid at all costs!
+	return (
+		validModels.find((model) => model === 'gpt-4o') ??
+		validModels.find((model) => model === 'gpt-4-turbo') ??
+		validModels.find((model) => model === 'gpt-3.5-turbo') ??
+		validModels[0]
+	);
 }
 
 function initQAModel(level: LEVEL_NAMES, Prompt: string) {

--- a/backend/src/models/chat.ts
+++ b/backend/src/models/chat.ts
@@ -7,14 +7,20 @@ import { ChatInfoMessage, ChatMessage } from './chatMessage';
 import { DEFENCE_ID } from './defence';
 import { EmailInfo } from './email';
 
-const chatModelIds = [
-	'gpt-4-1106-preview',
-	'gpt-4',
-	'gpt-4-0613',
-	'gpt-3.5-turbo',
-] as const;
+// Size of each model's context window in number of tokens
+// https://platform.openai.com/docs/models
+const chatModelContextWindow = {
+	'gpt-4o': 128000,
+	'gpt-4-turbo': 128000,
+	'gpt-4': 8192,
+	'gpt-3.5-turbo': 16385,
+} as const;
 
-type CHAT_MODEL_ID = (typeof chatModelIds)[number];
+type CHAT_MODEL_ID = keyof typeof chatModelContextWindow;
+
+const chatModelIds = Object.freeze(
+	Object.keys(chatModelContextWindow)
+) as readonly [CHAT_MODEL_ID];
 
 type ChatModel = {
 	id: CHAT_MODEL_ID;
@@ -103,6 +109,7 @@ const defaultChatModel: ChatModel = {
 };
 
 export type {
+	CHAT_MODEL_ID,
 	DefenceReport,
 	ChatModel,
 	ChatModelConfigurations,
@@ -116,5 +123,9 @@ export type {
 	SingleDefenceReport,
 	MODEL_CONFIG_ID,
 };
-export { defaultChatModel, modelConfigIds, chatModelIds };
-export type { CHAT_MODEL_ID };
+export {
+	defaultChatModel,
+	modelConfigIds,
+	chatModelIds,
+	chatModelContextWindow,
+};

--- a/backend/src/openai.ts
+++ b/backend/src/openai.ts
@@ -129,7 +129,7 @@ async function getValidModelsFromOpenAI() {
 		console.debug('Valid OpenAI models:', validModels);
 		return validModels;
 	} catch (error) {
-		console.error('Error getting valid models: ', error);
+		console.error('Error getting valid models:', error);
 		throw error;
 	}
 }

--- a/backend/test/unit/langchain.ts/initialisePromptEvaluationModel.test.ts
+++ b/backend/test/unit/langchain.ts/initialisePromptEvaluationModel.test.ts
@@ -60,21 +60,35 @@ test('GIVEN the prompt evaluation model is not initialised WHEN it is asked to e
 	expect(result).toEqual(false);
 });
 
-test('GIVEN the users api key supports GPT-4 WHEN the prompt evaluation model is initialised THEN it is initialised with GPT-4', async () => {
-	mockValidModels = ['gpt-4', 'gpt-3.5-turbo', 'gpt-3'];
+test('GIVEN the users api key supports gpt-4o WHEN the prompt evaluation model is initialised THEN it is initialised with gpt-4o', async () => {
+	mockValidModels = ['gpt-4o', 'gpt-4-turbo', 'gpt-3.5-turbo', 'gpt-3'];
 
 	const prompt = 'this is a test prompt. ';
 
 	await evaluatePrompt('some input', prompt);
 
 	expect(OpenAI).toHaveBeenCalledWith({
-		modelName: 'gpt-4',
+		modelName: 'gpt-4o',
 		temperature: 0,
 		openAIApiKey: 'sk-12345',
 	});
 });
 
-test('GIVEN the users api key does not support GPT-4 WHEN the prompt evaluation model is initialised THEN it is initialised with gpt-3.5-turbo', async () => {
+test('GIVEN the users api key supports gpt-4-turbo but not gpt-4o WHEN the prompt evaluation model is initialised THEN it is initialised with gpt-4-turbo', async () => {
+	mockValidModels = ['gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo', 'gpt-3'];
+
+	const prompt = 'this is a test prompt. ';
+
+	await evaluatePrompt('some input', prompt);
+
+	expect(OpenAI).toHaveBeenCalledWith({
+		modelName: 'gpt-4-turbo',
+		temperature: 0,
+		openAIApiKey: 'sk-12345',
+	});
+});
+
+test('GIVEN the users api key does not support gpt-4o or gpt-4-turbo WHEN the prompt evaluation model is initialised THEN it is initialised with gpt-3.5-turbo', async () => {
 	mockValidModels = ['gpt-2', 'gpt-3.5-turbo', 'gpt-3'];
 
 	const prompt = 'this is a test prompt. ';

--- a/backend/test/unit/langchain.ts/initialiseQAModel.test.ts
+++ b/backend/test/unit/langchain.ts/initialiseQAModel.test.ts
@@ -123,8 +123,8 @@ test('GIVEN the QA LLM WHEN a question is asked THEN it is initialised AND it an
 	expect(answer).toEqual(expectedAnswer);
 });
 
-test('GIVEN the users api key supports GPT-4 WHEN the QA model is initialised THEN it is initialised with GPT-4', async () => {
-	mockValidModels.push('gpt-4', 'gpt-3.5-turbo', 'gpt-3');
+test('GIVEN the users api key supports gpt-4o WHEN the QA model is initialised THEN it is initialised with gpt-4o', async () => {
+	mockValidModels.push('gpt-4o', 'gpt-4-turbo', 'gpt-3.5-turbo', 'gpt-3');
 
 	const level = LEVEL_NAMES.LEVEL_1;
 	const prompt = 'this is a test prompt. ';
@@ -132,13 +132,28 @@ test('GIVEN the users api key supports GPT-4 WHEN the QA model is initialised TH
 	await queryDocuments('some question', prompt, level);
 
 	expect(ChatOpenAI).toHaveBeenCalledWith({
-		modelName: 'gpt-4',
+		modelName: 'gpt-4o',
 		streaming: true,
 		openAIApiKey: 'sk-12345',
 	});
 });
 
-test('GIVEN the users api key does not support GPT-4 WHEN the QA model is initialised THEN it is initialised with gpt-3.5-turbo', async () => {
+test('GIVEN the users api key supports gpt-4-turbo but not gpt-4o WHEN the QA model is initialised THEN it is initialised with gpt-4-turbo', async () => {
+	mockValidModels.push('gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo', 'gpt-3');
+
+	const level = LEVEL_NAMES.LEVEL_1;
+	const prompt = 'this is a test prompt. ';
+
+	await queryDocuments('some question', prompt, level);
+
+	expect(ChatOpenAI).toHaveBeenCalledWith({
+		modelName: 'gpt-4o',
+		streaming: true,
+		openAIApiKey: 'sk-12345',
+	});
+});
+
+test('GIVEN the users api key does not support gpt-4o or gpt-4-turbo WHEN the QA model is initialised THEN it is initialised with gpt-3.5-turbo', async () => {
 	mockValidModels.push('gpt-2', 'gpt-3.5-turbo', 'gpt-3');
 
 	const level = LEVEL_NAMES.LEVEL_1;

--- a/backend/test/unit/openai.ts/getValidModelsFromOpenai.test.ts
+++ b/backend/test/unit/openai.ts/getValidModelsFromOpenai.test.ts
@@ -38,11 +38,11 @@ describe('getValidModelsFromOpenAI', () => {
 			{ id: 'gpt-3.5-turbo' },
 			{ id: 'gpt-3.5-turbo-0613' },
 			{ id: 'gpt-4' },
-			{ id: 'gpt-4-0613' },
+			{ id: 'gpt-4o' },
 			{ id: 'da-vinci-1' },
 			{ id: 'da-vinci-2' },
 		];
-		const expectedValidModels = ['gpt-3.5-turbo', 'gpt-4', 'gpt-4-0613'];
+		const expectedValidModels = ['gpt-3.5-turbo', 'gpt-4', 'gpt-4o'];
 
 		mockListFn.mockResolvedValueOnce({
 			data: mockModelList,

--- a/backend/test/unit/openai.ts/getValidModelsFromOpenai.test.ts
+++ b/backend/test/unit/openai.ts/getValidModelsFromOpenai.test.ts
@@ -52,4 +52,22 @@ describe('getValidModelsFromOpenAI', () => {
 
 		expect(validModels).toEqual(expectedValidModels);
 	});
+
+	test('GIVEN the user has no valid chat models available WHEN getValidModelsFromOpenAI is called THEN an error is thrown', async () => {
+		process.env.OPENAI_API_KEY = 'sk-12345';
+		const mockModelList = [
+			{ id: 'gpt-3' },
+			{ id: 'davinci-001' },
+			{ id: 'davinci-002' },
+			{ id: 'text-moderation-stable' },
+			{ id: 'whisper-1' },
+		];
+		mockListFn.mockResolvedValueOnce({
+			data: mockModelList,
+		} as OpenAI.ModelsPage);
+
+		await expect(getValidModelsFromOpenAI()).rejects.toThrow(
+			'No chat models found'
+		);
+	});
 });

--- a/frontend/src/components/ControlPanel/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel/ControlPanel.tsx
@@ -3,7 +3,7 @@ import DefenceBox from '@src/components/DefenceBox/DefenceBox';
 import ModelBox from '@src/components/ModelBox/ModelBox';
 import DetailElement from '@src/components/ThemedButtons/DetailElement';
 import ThemedButton from '@src/components/ThemedButtons/ThemedButton';
-import { CHAT_MODEL_ID, ChatMessage, ChatModel } from '@src/models/chat';
+import { ChatMessage, ChatModel } from '@src/models/chat';
 import {
 	DEFENCE_ID,
 	DefenceConfigItem,
@@ -29,7 +29,7 @@ function ControlPanel({
 	currentLevel: LEVEL_NAMES;
 	defences: Defence[];
 	chatModel?: ChatModel;
-	setChatModelId: (modelId: CHAT_MODEL_ID) => void;
+	setChatModelId: (modelId: ChatModel['id']) => void;
 	chatModelOptions: string[];
 	toggleDefence: (defence: Defence) => void;
 	resetDefenceConfiguration: (

--- a/frontend/src/components/MainComponent/MainBody.tsx
+++ b/frontend/src/components/MainComponent/MainBody.tsx
@@ -1,7 +1,7 @@
 import ChatBox from '@src/components/ChatBox/ChatBox';
 import ControlPanel from '@src/components/ControlPanel/ControlPanel';
 import EmailBox from '@src/components/EmailBox/EmailBox';
-import { CHAT_MODEL_ID, ChatMessage, ChatModel } from '@src/models/chat';
+import { ChatMessage, ChatModel } from '@src/models/chat';
 import {
 	DEFENCE_ID,
 	DefenceConfigItem,
@@ -36,7 +36,7 @@ function MainBody({
 	emails: EmailInfo[];
 	messages: ChatMessage[];
 	chatModel?: ChatModel;
-	setChatModelId: (modelId: CHAT_MODEL_ID) => void;
+	setChatModelId: (modelId: ChatModel['id']) => void;
 	chatModels: string[];
 	addChatMessage: (message: ChatMessage) => void;
 	addSentEmails: (emails: EmailInfo[]) => void;

--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -5,7 +5,7 @@ import HandbookOverlay from '@src/components/HandbookOverlay/HandbookOverlay';
 import LevelMissionInfoBanner from '@src/components/LevelMissionInfoBanner/LevelMissionInfoBanner';
 import ResetLevelOverlay from '@src/components/Overlay/ResetLevel';
 import ResetProgressOverlay from '@src/components/Overlay/ResetProgress';
-import { CHAT_MODEL_ID, ChatMessage, ChatModel } from '@src/models/chat';
+import { ChatMessage, ChatModel } from '@src/models/chat';
 import {
 	DEFENCE_ID,
 	DefenceConfigItem,
@@ -55,7 +55,7 @@ function MainComponent({
 	resetCompletedLevels: () => void;
 	setIsNewUser: (isNewUser: boolean) => void;
 }) {
-	const [MainBodyKey, setMainBodyKey] = useState<number>(0);
+	const [mainBodyKey, setMainBodyKey] = useState<number>(0);
 	const [defences, setDefences] = useState<Defence[]>(DEFAULT_DEFENCES);
 	const [messages, setMessages] = useState<ChatMessage[]>([]);
 	const [emails, setEmails] = useState<EmailInfo[]>([]);
@@ -184,9 +184,10 @@ function MainComponent({
 
 		setDefences(defences);
 
-		// we will only update the chatModel if it is defined in the backend response. It will only defined for the sandbox level.
+		// Will only update chatModel if included in the backend response
+		// (currently only for sandbox level)
 		setChatModel(chatModel);
-		setMainBodyKey(MainBodyKey + 1);
+		setMainBodyKey((value) => value + 1);
 	}
 
 	function addInfoMessage(message: string) {
@@ -290,7 +291,7 @@ function MainComponent({
 		}
 	}
 
-	function setChatModelId(modelId: CHAT_MODEL_ID) {
+	function setChatModelId(modelId: ChatModel['id']) {
 		if (!chatModel) {
 			console.error(
 				'You are trying to change the id of the chatModel but it has not been loaded yet'
@@ -355,7 +356,7 @@ function MainComponent({
 				/>
 			)}
 			<MainBody
-				key={MainBodyKey}
+				key={mainBodyKey}
 				currentLevel={currentLevel}
 				defences={defences}
 				chatModel={chatModel}

--- a/frontend/src/components/ModelBox/ModelBox.tsx
+++ b/frontend/src/components/ModelBox/ModelBox.tsx
@@ -1,4 +1,4 @@
-import { CHAT_MODEL_ID, ChatMessage, ChatModel } from '@src/models/chat';
+import { ChatMessage, ChatModel } from '@src/models/chat';
 
 import ModelConfiguration from './ModelConfiguration';
 import ModelSelection from './ModelSelection';
@@ -12,7 +12,7 @@ function ModelBox({
 	addChatMessage,
 }: {
 	chatModel?: ChatModel;
-	setChatModelId: (modelId: CHAT_MODEL_ID) => void;
+	setChatModelId: (modelId: ChatModel['id']) => void;
 	chatModelOptions: string[];
 	addChatMessage: (chatMessage: ChatMessage) => void;
 }) {

--- a/frontend/src/components/ModelBox/ModelSelection.tsx
+++ b/frontend/src/components/ModelBox/ModelSelection.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 
 import LoadingButton from '@src/components/ThemedButtons/LoadingButton';
-import { CHAT_MODEL_ID, ChatMessage, ChatModel } from '@src/models/chat';
+import { ChatMessage, ChatModel } from '@src/models/chat';
 import { chatService } from '@src/service';
 
 import './ModelSelection.css';
@@ -15,14 +15,14 @@ function ModelSelection({
 	addChatMessage,
 }: {
 	chatModel?: ChatModel;
-	setChatModelId: (modelId: CHAT_MODEL_ID) => void;
+	setChatModelId: (modelId: ChatModel['id']) => void;
 	chatModelOptions: string[];
 	addChatMessage: (message: ChatMessage) => void;
 }) {
 	// model currently selected in the dropdown
-	const [selectedModel, setSelectedModel] = useState<CHAT_MODEL_ID | undefined>(
-		undefined
-	);
+	const [selectedModel, setSelectedModel] = useState<
+		ChatModel['id'] | undefined
+	>(chatModel?.id);
 
 	const [errorChangingModel, setErrorChangingModel] = useState(false);
 
@@ -65,7 +65,7 @@ function ModelSelection({
 									aria-label="model-select"
 									value={selectedModel ?? 0} // default to the first model
 									onChange={(e) => {
-										setSelectedModel(e.target.value as CHAT_MODEL_ID);
+										setSelectedModel(e.target.value);
 									}}
 								>
 									{chatModelOptions.map((model) => (

--- a/frontend/src/models/chat.ts
+++ b/frontend/src/models/chat.ts
@@ -15,20 +15,8 @@ type CHAT_MESSAGE_TYPE =
 	| 'ERROR_MSG'
 	| 'RESET_LEVEL';
 
-const chatModelIds = [
-	'gpt-4-1106-preview',
-	'gpt-4',
-	'gpt-4-0613',
-	'gpt-3.5-turbo',
-	'gpt-3.5-turbo-0613',
-	'gpt-3.5-turbo-16k',
-	'gpt-3.5-turbo-16k-0613',
-] as const;
-
-type CHAT_MODEL_ID = (typeof chatModelIds)[number];
-
 type ChatModel = {
-	id: CHAT_MODEL_ID;
+	id: string;
 	configuration: ChatModelConfigurations;
 };
 
@@ -107,5 +95,4 @@ export type {
 	CustomChatModelConfiguration,
 	CHAT_MESSAGE_TYPE,
 	MODEL_CONFIG_ID,
-	CHAT_MODEL_ID,
 };


### PR DESCRIPTION
## Description

Adds GPT-4 Turbo and GPT-4o, removes some preview models.

resolves #912 

## Screenshots

Server startup:
![image](https://github.com/ScottLogic/prompt-injection/assets/15246391/24d5c6aa-fafd-42be-8832-5dfe1a83023d)

UI available models
![image](https://github.com/ScottLogic/prompt-injection/assets/15246391/dfb933ab-66cc-444f-83b0-269ffbf25784)

## Notes

- GPT-4 is really expensive, so default QA / Prompt Eval model is now GPT-4o
- Chat model (selectable in UI) is still GPT-3.5 Turbo by default, as it's cheap as chips and the important work is performed by the other two models

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [x] Added tests
- [x] Ensured the workflow steps are passing
